### PR TITLE
Update skaled and skale-admin versions

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "3.17.0-beta.2",
+    "version": "3.17.0-beta.5",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.11.0-static-accounts-build.1
+    image: skalenetwork/admin:2.11.0-beta-sync-node.7
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.11.0-beta-sync-node.7
+    image: skalenetwork/admin:2.11.0-static-accounts-build.1
     network_mode: host
     tty: true
     cap_add:


### PR DESCRIPTION
Bump skaled to 3.17.0-beta.5. Bump admin to make it compatible with static predeployed