### PR TITLE
Fix timestamps. Move getLogsBlockLimit to base config

### DIFF
--- a/schain_base_config.json
+++ b/schain_base_config.json
@@ -22,7 +22,7 @@
 		"blockReward": "0x4563918244F40000",
 		"externalGasDifficulty": "0x01",
 		"skaleDisableChainIdCheck": true,
-        "getLogsBlocksLimit": 2000
+                "getLogsBlocksLimit": 2000
 	},
 	"unddos": {
 		"origins": [

--- a/schain_base_config.json
+++ b/schain_base_config.json
@@ -21,7 +21,8 @@
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
 		"externalGasDifficulty": "0x01",
-		"skaleDisableChainIdCheck": true
+		"skaleDisableChainIdCheck": true,
+        "getLogsBlocksLimit": 2000
 	},
 	"unddos": {
 		"origins": [

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -44,10 +44,10 @@ envs:
       storageDestructionPatchTimestamp: 1703851200
       powCheckPatchTimestamp: 1703592000
       skipInvalidTransactionsPatchTimestamp: 1703764800
-      pushZeroPatchTimestamp: 0
-      precompiledConfigPatchTimestamp: 0
-      correctForkInPowPatchTimestamp: 0
-      eip1559TransactionsPatchTimestamp: 0
+      pushZeroPatchTimestamp: 1712142000
+      precompiledConfigPatchTimestamp: 1712314800
+      correctForkInPowPatchTimestamp: 1711969200
+      EIP1559TransactionsPatchTimestamp: 0
       fastConsensusPatchTimestamp: 0
       flexibleDeploymentPatchTimestamp:
         honorable-steel-rasalhague: 0
@@ -59,7 +59,11 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      getLogsBlocksLimit: 2000
+
+    ima:
+      time_frame:
+        before: 1800
+        after: 900
 
     schain_cmd:
       ["-v 2", "--aa no"]
@@ -145,10 +149,10 @@ envs:
       storageDestructionPatchTimestamp: 1702393200
       powCheckPatchTimestamp: 1702296000
       skipInvalidTransactionsPatchTimestamp: 1702382400
-      pushZeroPatchTimestamp: 0
-      precompiledConfigPatchTimestamp: 0
-      correctForkInPowPatchTimestamp: 0
-      eip1559TransactionsPatchTimestamp: 0
+      pushZeroPatchTimestamp: 1710331200
+      precompiledConfigPatchTimestamp: 1710331200
+      correctForkInPowPatchTimestamp: 1710331200
+      EIP1559TransactionsPatchTimestamp: 0
       fastConsensusPatchTimestamp: 0
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 0
@@ -156,7 +160,6 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      getLogsBlocksLimit: 2000
 
     ima:
       time_frame:
@@ -247,10 +250,10 @@ envs:
       storageDestructionPatchTimestamp: 1699618500
       powCheckPatchTimestamp: 1699625700
       skipInvalidTransactionsPatchTimestamp: 1699632900
-      pushZeroPatchTimestamp: 0
-      precompiledConfigPatchTimestamp: 0
-      correctForkInPowPatchTimestamp: 0
-      eip1559TransactionsPatchTimestamp: 0
+      pushZeroPatchTimestamp: 1712142000
+      precompiledConfigPatchTimestamp: 1712314800
+      correctForkInPowPatchTimestamp: 1711969200
+      EIP1559TransactionsPatchTimestamp: 0
       fastConsensusPatchTimestamp: 0
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 0
@@ -258,7 +261,6 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      getLogsBlocksLimit: 2000
 
     ima:
       time_frame:
@@ -351,10 +353,10 @@ envs:
       storageDestructionPatchTimestamp: 1000000
       powCheckPatchTimestamp: 1000000
       skipInvalidTransactionsPatchTimestamp: 1000000
-      pushZeroPatchTimestamp: 0
-      precompiledConfigPatchTimestamp: 0
-      correctForkInPowPatchTimestamp: 0
-      eip1559TransactionsPatchTimestamp: 0
+      pushZeroPatchTimestamp: 1712142000
+      precompiledConfigPatchTimestamp: 1712314800
+      correctForkInPowPatchTimestamp: 1711969200
+      EIP1559TransactionsPatchTimestamp: 0
       fastConsensusPatchTimestamp: 0
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 0
@@ -362,7 +364,6 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      getLogsBlocksLimit: 2000
 
     ima:
       time_frame:


### PR DESCRIPTION
Changes:
- Move `getLogsBlocksLimit` to `schain_base_config.json`.
- Fix 2.4 patch timestamps.
Testing:
- No test needed.
Performance:
- No performance changes were introduced.