### PR TITLE
Update patch timestamp, update skaled version

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.0-beta.0",
+    "version": "4.0.0-beta.1",
     "custom_args": {
       "ulimits_list": [
         {

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -78,7 +78,7 @@ envs:
         parallel-stormy-spica: 1723460400
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1728817200
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
@@ -90,8 +90,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -182,7 +181,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 1721826000
       verifyBlsSyncPatchTimestamp: 1721829600
       externalGasPatchTimestamp: 1727712000
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
@@ -194,8 +193,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -286,7 +284,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 0
       externalGasPatchTimestamp: 1727712000
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
@@ -298,8 +296,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -392,7 +389,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1727353446
-      maxFeePerGasPatchTimestamp: 1741956440
+      invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000


### PR DESCRIPTION
In this PR:

- Update `maxFeePerGasPatchTimestamp` to `invalidTransactionFormatPatchTimestamp`
- Bump skaled version