### PR TITLE
Add Docker Compose and static configuration for Mirage node type

### DIFF
--- a/docker-compose-mirage.yml
+++ b/docker-compose-mirage.yml
@@ -1,0 +1,269 @@
+version: '3.4'
+
+services:
+  base: &skale_base
+    image: rancher/pause:3.6
+    restart: unless-stopped
+    labels:
+      com.skale.prefix: "node"
+    cpu_shares: 128
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+
+  transaction-manager:
+    <<: *skale_base
+    container_name: skale_transaction-manager
+    image: skalenetwork/transaction-manager:2.3.0
+    network_mode: host
+    tty: true
+    environment:
+      SGX_URL: ${SGX_SERVER_URL}
+      ENDPOINT: ${ENDPOINT}
+    volumes:
+      - ${SKALE_DIR}:/skale_vol
+      - ${SKALE_DIR}/node_data:/skale_node_data
+
+  mirage-boot:
+    <<: *skale_base
+    container_name: mirage-boot
+    image: skalenetwork/admin:2.10.0-beta.1
+    cpu_shares: 192
+    network_mode: host
+    tty: true
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      SGX_SERVER_URL: ${SGX_SERVER_URL}
+      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
+      ENDPOINT: ${ENDPOINT}
+      SKALE_DIR_HOST: ${SKALE_DIR}
+      TG_API_KEY: ${TG_API_KEY}
+      TG_CHAT_ID: ${TG_CHAT_ID}
+      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
+      BACKUP_RUN: ${BACKUP_RUN}
+      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
+      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
+      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
+      MAX_ALLOWED_LOG_TIME_DIFF: 600
+      ENV_TYPE: ${ENV_TYPE}
+      ALLOWED_TS_DIFF: 300
+      PULL_CONFIG_FOR_SCHAIN: ${PULL_CONFIG_FOR_SCHAIN}
+      TELEGRAF: ${TELEGRAF}
+      INFLUX_URL: ${INFLUX_URL}
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+      IMA_CONTRACTS: ${IMA_CONTRACTS}
+      SKALE_NETWORK_TYPE: "mirage"
+
+    command: "python3 admin.py"
+    volumes:
+      - /var/run/skale:/var/run/skale
+      - ${SKALE_DIR}:/skale_vol
+      - ${SKALE_DIR}/node_data:/skale_node_data
+      - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
+    healthcheck:
+      test: ["CMD", "python3", "healthchecks/admin.py"]
+      interval: 1m
+      timeout: 10s
+      retries: 2
+      start_period: 30s
+
+  mirage-admin:
+    <<: *skale_base
+    container_name: mirage-admin
+    image: skalenetwork/admin:2.10.0-beta.1
+    cpu_shares: 192
+    network_mode: host
+    tty: true
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      SGX_SERVER_URL: ${SGX_SERVER_URL}
+      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
+      ENDPOINT: ${ENDPOINT}
+      SKALE_DIR_HOST: ${SKALE_DIR}
+      TG_API_KEY: ${TG_API_KEY}
+      TG_CHAT_ID: ${TG_CHAT_ID}
+      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
+      BACKUP_RUN: ${BACKUP_RUN}
+      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
+      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
+      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
+      MAX_ALLOWED_LOG_TIME_DIFF: 600
+      ENV_TYPE: ${ENV_TYPE}
+      ALLOWED_TS_DIFF: 300
+      PULL_CONFIG_FOR_SCHAIN: ${PULL_CONFIG_FOR_SCHAIN}
+      TELEGRAF: ${TELEGRAF}
+      INFLUX_URL: ${INFLUX_URL}
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+
+    command: "python3 mirage.py"
+    volumes:
+      - /var/run/skale:/var/run/skale
+      - ${SKALE_DIR}:/skale_vol
+      - ${SKALE_DIR}/node_data:/skale_node_data
+      - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
+    healthcheck:
+      test: ["CMD", "python3", "healthchecks/admin.py"]
+      interval: 1m
+      timeout: 10s
+      retries: 2
+      start_period: 30s
+
+  skale-api:
+    <<: *skale_base
+    container_name: skale_api
+    image: skalenetwork/admin:2.10.0-beta.1
+    network_mode: host
+    tty: true
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      SGX_SERVER_URL: ${SGX_SERVER_URL}
+      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
+      ENDPOINT: ${ENDPOINT}
+      FLASK_SECRET_KEY: ${FLASK_SECRET_KEY}
+      FLASK_APP_PORT: 3007
+      FLASK_APP_HOST: "127.0.0.1"
+      FLASK_DEBUG_MODE: "False"
+      SKALE_DIR_HOST: ${SKALE_DIR}
+      TG_API_KEY: ${TG_API_KEY}
+      TG_CHAT_ID: ${TG_CHAT_ID}
+      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
+      BACKUP_RUN: ${BACKUP_RUN}
+      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
+      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
+      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
+      ENV_TYPE: ${ENV_TYPE}
+      ALLOWED_TS_DIFF: 300
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+      IMA_CONTRACTS: ${IMA_CONTRACTS}
+    command: "gunicorn app:app -c gunicorn.conf.py"
+    volumes:
+      - /var/run/skale:/var/run/skale
+      - ${SKALE_DIR}:/skale_vol
+      - ${SKALE_DIR}/node_data:/skale_node_data
+      - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
+
+  celery:
+    <<: *skale_base
+    container_name: celery
+    image: skalenetwork/admin:2.10.0-beta.1
+    network_mode: host
+    tty: true
+    environment:
+      TG_API_KEY: ${TG_API_KEY}
+      TG_CHAT_ID: ${TG_CHAT_ID}
+      SKALE_DIR_HOST: ${SKALE_DIR}
+    command: "celery -A tools.notifications.tasks worker --loglevel=info"
+
+    volumes:
+      - /var/run/skale:/var/run/skale
+
+  redis:
+    <<: *skale_base
+    container_name: skale_redis
+    image: "redis:6.0.10-alpine"
+    network_mode: host
+    tty: true
+    environment:
+      - REDIS_REPLICATION_MODE=master
+    command: "redis-server /data/redis.conf"
+    volumes:
+      - ${SKALE_DIR}/node_data/redis-data:/data/db:rw
+      - ${SKALE_DIR}/config/redis.conf:/data/redis.conf
+
+  bounty:
+    <<: *skale_base
+    container_name: skale_bounty
+    image: skalenetwork/bounty-agent:2.2.0-stable.0
+    network_mode: host
+    environment:
+      SGX_SERVER_URL: ${SGX_SERVER_URL}
+      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
+      ENDPOINT: ${ENDPOINT}
+      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
+      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
+      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
+      ALLOWED_TS_DIFF: 300
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+      IMA_CONTRACTS: ${IMA_CONTRACTS}
+    volumes:
+      - ${SKALE_DIR}:/skale_vol
+      - ${SKALE_DIR}/node_data:/skale_node_data
+
+  watchdog:
+    <<: *skale_base
+    container_name: skale_watchdog
+    image: skalenetwork/watchdog:2.2.0-stable.0
+    network_mode: host
+    environment:
+      ALLOWED_TS_DIFF: 300
+      FLASK_APP_PORT: 3010
+      FLASK_APP_HOST: "127.0.0.1"
+      FLASK_DEBUG_MODE: "False"
+
+  nginx:
+    <<: *skale_base
+    image: nginx:1.20.2
+    container_name: skale_nginx
+    network_mode: host
+    depends_on:
+      - watchdog
+    volumes:
+      - ${SKALE_DIR}/node_data/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${SKALE_DIR}/node_data/ssl:/ssl:ro
+      - ${FILESTORAGE_MAPPING}:/filestorage:ro
+      - type: bind
+        bind:
+          propagation: slave
+        source: ${SCHAINS_MNT_DIR}
+        target: ${SCHAINS_MNT_DIR}
+        read_only: true
+
+  advisor:
+    <<: *skale_base
+    image: gcr.io/cadvisor/cadvisor-amd64:v0.50.0
+    container_name: monitor_cadvisor
+    cpu_shares: 128
+    network_mode: host
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+
+  node-exporter:
+    <<: *skale_base
+    container_name: monitor_node_exporter
+    image: quay.io/prometheus/node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+    network_mode: host
+
+  filebeat:
+    <<: *skale_base
+    container_name: skale_filebeat
+    user: root
+    image: docker.elastic.co/beats/filebeat:7.3.1
+    network_mode: host
+    environment:
+      FILEBEAT_HOST: ${FILEBEAT_HOST}
+    volumes:
+      - ${SKALE_DIR}/node_data/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /var/log/docker-lvmpy:/var/log/docker-lvmpy:ro
+      - /var/run/skale:/var/run/skale

--- a/docker-compose-mirage.yml
+++ b/docker-compose-mirage.yml
@@ -15,7 +15,7 @@ services:
 
   transaction-manager:
     <<: *skale_base
-    container_name: mirage_transaction-manager
+    container_name: skale_transaction-manager
     image: skalenetwork/transaction-manager:2.3.0
     network_mode: host
     tty: true
@@ -144,7 +144,7 @@ services:
 
   redis:
     <<: *skale_base
-    container_name: mirage_redis
+    container_name: skale_redis
     image: "redis:6.0.10-alpine"
     network_mode: host
     tty: true
@@ -157,7 +157,7 @@ services:
 
   watchdog:
     <<: *skale_base
-    container_name: mirage_watchdog
+    container_name: skale_watchdog
     image: skalenetwork/watchdog:2.2.0-stable.0
     network_mode: host
     environment:
@@ -169,7 +169,7 @@ services:
   nginx:
     <<: *skale_base
     image: nginx:1.20.2
-    container_name: mirage_nginx
+    container_name: skale_nginx
     network_mode: host
     depends_on:
       - watchdog
@@ -213,7 +213,7 @@ services:
 
   filebeat:
     <<: *skale_base
-    container_name: mirage_filebeat
+    container_name: skale_filebeat
     user: root
     image: docker.elastic.co/beats/filebeat:7.3.1
     network_mode: host

--- a/docker-compose-mirage.yml
+++ b/docker-compose-mirage.yml
@@ -15,7 +15,7 @@ services:
 
   transaction-manager:
     <<: *skale_base
-    container_name: skale_transaction-manager
+    container_name: mirage_transaction-manager
     image: skalenetwork/transaction-manager:2.3.0
     network_mode: host
     tty: true
@@ -28,7 +28,7 @@ services:
 
   mirage-boot:
     <<: *skale_base
-    container_name: mirage-boot
+    container_name: mirage_boot_admin
     image: skalenetwork/admin:2.10.0-beta.1
     cpu_shares: 192
     network_mode: host
@@ -70,7 +70,7 @@ services:
 
   mirage-admin:
     <<: *skale_base
-    container_name: mirage-admin
+    container_name: mirage_admin
     image: skalenetwork/admin:2.10.0-beta.1
     cpu_shares: 192
     network_mode: host
@@ -110,7 +110,7 @@ services:
 
   skale-api:
     <<: *skale_base
-    container_name: skale_api
+    container_name: mirage_api
     image: skalenetwork/admin:2.10.0-beta.1
     network_mode: host
     tty: true
@@ -144,7 +144,7 @@ services:
 
   redis:
     <<: *skale_base
-    container_name: skale_redis
+    container_name: mirage_redis
     image: "redis:6.0.10-alpine"
     network_mode: host
     tty: true
@@ -157,7 +157,7 @@ services:
 
   watchdog:
     <<: *skale_base
-    container_name: skale_watchdog
+    container_name: mirage_watchdog
     image: skalenetwork/watchdog:2.2.0-stable.0
     network_mode: host
     environment:
@@ -169,7 +169,7 @@ services:
   nginx:
     <<: *skale_base
     image: nginx:1.20.2
-    container_name: skale_nginx
+    container_name: mirage_nginx
     network_mode: host
     depends_on:
       - watchdog
@@ -213,7 +213,7 @@ services:
 
   filebeat:
     <<: *skale_base
-    container_name: skale_filebeat
+    container_name: mirage_filebeat
     user: root
     image: docker.elastic.co/beats/filebeat:7.3.1
     network_mode: host

--- a/docker-compose-mirage.yml
+++ b/docker-compose-mirage.yml
@@ -41,8 +41,6 @@ services:
       SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
       ENDPOINT: ${ENDPOINT}
       SKALE_DIR_HOST: ${SKALE_DIR}
-      TG_API_KEY: ${TG_API_KEY}
-      TG_CHAT_ID: ${TG_CHAT_ID}
       MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
       BACKUP_RUN: ${BACKUP_RUN}
       DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
@@ -51,7 +49,6 @@ services:
       MAX_ALLOWED_LOG_TIME_DIFF: 600
       ENV_TYPE: ${ENV_TYPE}
       ALLOWED_TS_DIFF: 300
-      PULL_CONFIG_FOR_SCHAIN: ${PULL_CONFIG_FOR_SCHAIN}
       TELEGRAF: ${TELEGRAF}
       INFLUX_URL: ${INFLUX_URL}
       MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
@@ -86,8 +83,6 @@ services:
       SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
       ENDPOINT: ${ENDPOINT}
       SKALE_DIR_HOST: ${SKALE_DIR}
-      TG_API_KEY: ${TG_API_KEY}
-      TG_CHAT_ID: ${TG_CHAT_ID}
       MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
       BACKUP_RUN: ${BACKUP_RUN}
       DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
@@ -96,7 +91,6 @@ services:
       MAX_ALLOWED_LOG_TIME_DIFF: 600
       ENV_TYPE: ${ENV_TYPE}
       ALLOWED_TS_DIFF: 300
-      PULL_CONFIG_FOR_SCHAIN: ${PULL_CONFIG_FOR_SCHAIN}
       TELEGRAF: ${TELEGRAF}
       INFLUX_URL: ${INFLUX_URL}
       MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
@@ -132,8 +126,6 @@ services:
       FLASK_APP_HOST: "127.0.0.1"
       FLASK_DEBUG_MODE: "False"
       SKALE_DIR_HOST: ${SKALE_DIR}
-      TG_API_KEY: ${TG_API_KEY}
-      TG_CHAT_ID: ${TG_CHAT_ID}
       MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
       BACKUP_RUN: ${BACKUP_RUN}
       DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
@@ -150,21 +142,6 @@ services:
       - ${SKALE_DIR}/node_data:/skale_node_data
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
 
-  celery:
-    <<: *skale_base
-    container_name: celery
-    image: skalenetwork/admin:2.10.0-beta.1
-    network_mode: host
-    tty: true
-    environment:
-      TG_API_KEY: ${TG_API_KEY}
-      TG_CHAT_ID: ${TG_CHAT_ID}
-      SKALE_DIR_HOST: ${SKALE_DIR}
-    command: "celery -A tools.notifications.tasks worker --loglevel=info"
-
-    volumes:
-      - /var/run/skale:/var/run/skale
-
   redis:
     <<: *skale_base
     container_name: skale_redis
@@ -177,25 +154,6 @@ services:
     volumes:
       - ${SKALE_DIR}/node_data/redis-data:/data/db:rw
       - ${SKALE_DIR}/config/redis.conf:/data/redis.conf
-
-  bounty:
-    <<: *skale_base
-    container_name: skale_bounty
-    image: skalenetwork/bounty-agent:2.2.0-stable.0
-    network_mode: host
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      ENDPOINT: ${ENDPOINT}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      ALLOWED_TS_DIFF: 300
-      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
-      IMA_CONTRACTS: ${IMA_CONTRACTS}
-    volumes:
-      - ${SKALE_DIR}:/skale_vol
-      - ${SKALE_DIR}/node_data:/skale_node_data
 
   watchdog:
     <<: *skale_base
@@ -218,7 +176,6 @@ services:
     volumes:
       - ${SKALE_DIR}/node_data/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ${SKALE_DIR}/node_data/ssl:/ssl:ro
-      - ${FILESTORAGE_MAPPING}:/filestorage:ro
       - type: bind
         bind:
           propagation: slave

--- a/docker-compose-mirage.yml
+++ b/docker-compose-mirage.yml
@@ -108,7 +108,7 @@ services:
       retries: 2
       start_period: 30s
 
-  skale-api:
+  mirage-api:
     <<: *skale_base
     container_name: mirage_api
     image: skalenetwork/admin:2.10.0-beta.1

--- a/nginx.conf.j2
+++ b/nginx.conf.j2
@@ -33,6 +33,7 @@ server {
     }
 }
 
+{% if regular_node %}
 server {
     listen 80;
 
@@ -51,3 +52,4 @@ server {
         root /filestorage;
     }
 }
+{% endif %}

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -44,13 +44,13 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 500000000000
-      network: true
 
     package:
       iptables-persistent: 1.0.4
       btrfs-progs: 4.15.1
       lsof: "4.89"
       psmisc: 23.1-1
+      lvm2: disabled
 
     docker:
       docker-api: 1.41.0
@@ -72,13 +72,13 @@ envs:
       memory: 2000000000
       swap: 2000000000
       disk: 80000000000
-      network: true
 
     package:
       iptables-persistent: 1.0.4
       btrfs-progs: 4.15.1
       lsof: "4.89"
       psmisc: 23.1-1
+      lvm2: disabled
 
     docker:
       docker-api: 1.41.0
@@ -101,7 +101,6 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 1900000000000
-      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -210,7 +209,6 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 200000000000
-      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -314,7 +312,6 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 200000000000
-      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -420,7 +417,6 @@ envs:
       memory: 2000000000
       swap: 2000000000
       disk: 80000000000
-      network: true
 
     package:
       iptables-persistent: 1.0.4

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -37,6 +37,61 @@ common:
       db_storage: 0.2 # leveldb may use x2 storage, so 0.4 divided by 2, actually using 0.4
     shared_space_coefficient: 1
 envs:
+  mainnet-mirage:
+    server:
+      cpu_total: 8
+      cpu_physical: 1
+      memory: 32000000000
+      swap: 16000000000
+      disk: 500000000000
+
+    package:
+      iptables-persistent: 1.0.4
+      btrfs-progs: 4.15.1
+      lsof: "4.89"
+      psmisc: 23.1-1
+
+    docker:
+      docker-api: 1.41.0
+      docker-engine: 20.10.7
+      docker-compose: 1.27.4
+
+    schain:
+      snapshotIntervalSec: 86400
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
+
+    schain_cmd: ["-v 2", "--aa no"]
+
+  devnet-mirage:
+    server:
+      cpu_total: 1
+      cpu_physical: 1
+      memory: 2000000000
+      swap: 2000000000
+      disk: 80000000000
+
+    package:
+      iptables-persistent: 1.0.4
+      btrfs-progs: 4.15.1
+      lsof: "4.89"
+      psmisc: 23.1-1
+
+    docker:
+      docker-api: 1.41.0
+      docker-engine: 20.10.7
+      docker-compose: 1.27.4
+
+    schain:
+      snapshotIntervalSec: 86400
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
+
+    schain_cmd:
+      ["-v 3", "--web3-trace", "--enable-debug-behavior-apis", "--aa no"]
+
   mainnet:
     server:
       cpu_total: 8
@@ -90,8 +145,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -194,8 +248,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -298,8 +351,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -37,63 +37,6 @@ common:
       db_storage: 0.2 # leveldb may use x2 storage, so 0.4 divided by 2, actually using 0.4
     shared_space_coefficient: 1
 envs:
-  mainnet-mirage:
-    server:
-      cpu_total: 8
-      cpu_physical: 1
-      memory: 32000000000
-      swap: 16000000000
-      disk: 500000000000
-
-    package:
-      iptables-persistent: 1.0.4
-      btrfs-progs: 4.15.1
-      lsof: "4.89"
-      psmisc: 23.1-1
-      lvm2: disabled
-
-    docker:
-      docker-api: 1.41.0
-      docker-engine: 20.10.7
-      docker-compose: 1.27.4
-
-    schain:
-      snapshotIntervalSec: 86400
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
-
-    schain_cmd: ["-v 2", "--aa no"]
-
-  devnet-mirage:
-    server:
-      cpu_total: 1
-      cpu_physical: 1
-      memory: 2000000000
-      swap: 2000000000
-      disk: 80000000000
-
-    package:
-      iptables-persistent: 1.0.4
-      btrfs-progs: 4.15.1
-      lsof: "4.89"
-      psmisc: 23.1-1
-      lvm2: disabled
-
-    docker:
-      docker-api: 1.41.0
-      docker-engine: 20.10.7
-      docker-compose: 1.27.4
-
-    schain:
-      snapshotIntervalSec: 86400
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
-
-    schain_cmd:
-      ["-v 3", "--web3-trace", "--enable-debug-behavior-apis", "--aa no"]
-
   mainnet:
     server:
       cpu_total: 8

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -44,6 +44,7 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 500000000000
+      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -71,6 +72,7 @@ envs:
       memory: 2000000000
       swap: 2000000000
       disk: 80000000000
+      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -99,6 +101,7 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 1900000000000
+      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -207,6 +210,7 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 200000000000
+      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -310,6 +314,7 @@ envs:
       memory: 32000000000
       swap: 16000000000
       disk: 200000000000
+      network: true
 
     package:
       iptables-persistent: 1.0.4
@@ -415,6 +420,7 @@ envs:
       memory: 2000000000
       swap: 2000000000
       disk: 80000000000
+      network: true
 
     package:
       iptables-persistent: 1.0.4


### PR DESCRIPTION
## Problem

The introduction of the "Mirage" node type requires a dedicated Docker Compose configuration to manage its specific services and operational phases (boot vs. regular admin).
Mirage nodes utilize a different configuration generation path within `skale-admin` (triggered by `SKALE_NETWORK_TYPE=mirage`) and have distinct environment requirements compared to standard SKALE nodes.
Furthermore, static parameters defining resource requirements and sChain configurations for different network types need to be updated to include Mirage environments.

## Solution

This pull request introduces the necessary configurations within the `skale-node` repository to support the orchestration and definition of Mirage nodes:

1.  **`docker-compose-mirage.yml` Added:**
    * A new Docker Compose file specifically for Mirage nodes has been created.
    * It defines the required services, including:
        * `mirage-boot`: Uses the standard `skalenetwork/admin` image but runs `python3 admin.py` as the command and critically sets the `SKALE_NETWORK_TYPE="mirage"` environment variable. It includes `IMA_CONTRACTS` but excludes `DOCKER_LVMPY_STREAM`.
        * `mirage-admin`: Uses the standard `skalenetwork/admin` image but runs the new `python3 mirage.py` entrypoint. It excludes `IMA_CONTRACTS` and `DOCKER_LVMPY_STREAM`.
        * Other standard services (`transaction-manager`, `skale-api`, `redis`, `watchdog`, `nginx`, `filebeat`, monitoring) are included with Mirage-specific container names (e.g., `mirage_transaction-manager`) and appropriate environment variables passed from the host `.env` file.
    * This file will be targeted by the `node-cli` commands `mirage boot init` and `mirage boot migrate`.

2.  **`nginx.conf.j2` Updated:**
    * The Nginx template now uses a `regular_node` variable (set by `node-cli` based on its type) to conditionally include the `/filestorage` server block, which is omitted for Mirage nodes.

3.  **`static_params.yaml` Updated:**
    * Added new environment definitions `mainnet-mirage` and `devnet-mirage`.
    * These specify distinct server requirements (CPU, memory, disk), package versions (if applicable), Docker versions, and sChain parameters for Mirage networks.

## Benefits

* **Mirage Orchestration:** Provides the necessary Docker Compose file for `node-cli` to manage the lifecycle of Mirage nodes.
* **Configuration Separation:** Clearly separates the service definitions and static parameters for Mirage nodes from standard SKALE nodes.
* **Supports Distinct Phases:** Defines separate services (`mirage-boot`, `mirage-admin`) to accommodate the different entrypoints and environment requirements of the Mirage boot and regular operational phases.
* **Environment Definition:** Adds static parameters for Mirage environments, enabling proper resource checking and configuration by `node-cli` and potentially `skale-admin`.

## Testing

* The primary validation for this PR involves integration testing with `node-cli` and `skale-admin`.
* Manual testing steps:
    * Use the updated `node-cli` (Mirage build).
    * Prepare a `.env` file suitable for a Mirage environment (e.g., `ENV_TYPE=devnet-mirage`).
    * Run `mirage boot init <env_file>`. Verify that Docker attempts to pull the correct images and start the services defined in `docker-compose-mirage.yml`, specifically the `mirage-boot` service. Check container logs for expected startup behavior and environment variables (especially `SKALE_NETWORK_TYPE` in `mirage-boot`).

## Reviewer Instructions

1.  **Review `docker-compose-mirage.yml`:**
    * Verify service definitions (`image` versions, `container_name` prefixes, `command` entrypoints for `mirage-boot` and `mirage-admin`).
    * Check environment variables passed to each service, paying close attention to the presence/absence of `SKALE_NETWORK_TYPE`, `IMA_CONTRACTS`, and `DOCKER_LVMPY_STREAM` as intended for Mirage.
    * Ensure volume mounts are correct.
2.  **Review `nginx.conf.j2`:** Confirm the conditional logic correctly omits the filestorage block when `regular_node` is false.
3.  **Review `static_params.yaml`:** Check the parameters defined for `mainnet-mirage` and `devnet-mirage` for correctness and completeness.
4.  **Integration Check:** Consider how these configurations align with the corresponding changes in `node-cli` (which reads this file) and `skale-admin` (which provides the entrypoints).