### PR TITLE
Ensure Mirage chainId is String in Static Params

### DIFF
--- a/mirage_static_params.yaml
+++ b/mirage_static_params.yaml
@@ -48,7 +48,7 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A6
+      chain_id: "0x3A6"
       chain_name: mirage
 
   testnet:
@@ -97,7 +97,7 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A7
+      chain_id: "0x3A7"
       chain_name: mirage-testnet
 
   qanet:
@@ -146,7 +146,7 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A9
+      chain_id: "0x3A9"
       chain_name: mirage-qa
 
   devnet:
@@ -196,5 +196,5 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A8
+      chain_id: "0x3A8"
       chain_name: mirage-devnet


### PR DESCRIPTION
## Description

Changed the `chainId` values in `mirage_static_params.yaml` to be explicitly quoted as strings (e.g., `"0x3A6"` instead of `0x3A6`).

This ensures that when `skale-admin` consumes this value, it's treated as a hexadecimal string, preventing automatic conversion to an integer.
The `chain_id` must be processed and passed on as a hex string.