### PR TITLE
Update redis to v8, update config

### DIFF
--- a/docker-compose-mirage.yml
+++ b/docker-compose-mirage.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   base: &skale_base
     image: rancher/pause:3.6
@@ -145,15 +143,16 @@ services:
   redis:
     <<: *skale_base
     container_name: skale_redis
-    image: "redis:6.0.10-alpine"
+    image: "redis:8.0.1-alpine"
     network_mode: host
     tty: true
     environment:
       - REDIS_REPLICATION_MODE=master
     command: "redis-server /data/redis.conf"
     volumes:
-      - ${SKALE_DIR}/node_data/redis-data:/data/db:rw
+      - ${SKALE_DIR}/node_data/redis-data:/data:rw
       - ${SKALE_DIR}/config/redis.conf:/data/redis.conf
+    restart: unless-stopped
 
   watchdog:
     <<: *skale_base

--- a/redis.conf
+++ b/redis.conf
@@ -1,36 +1,30 @@
-# Network
 bind 127.0.0.1
 protected-mode yes
 port 6379
 tcp-keepalive 300
 
-# General
 daemonize no
 supervised no
 loglevel notice
 databases 16
 
-# Persistence - RDB configuration
-save 900 1      # Save after 15 minutes if at least 1 key changed
-save 300 10     # Save after 5 minutes if at least 10 keys changed
-save 60 10000   # Save after 1 minute if at least 10000 keys changed
+save 900 1
+save 300 10
+save 60 10000
 dbfilename dump.rdb
 dir /data
 
-# Persistence - AOF configuration
-appendonly yes  # Changed to YES to enable AOF persistence
+appendonly yes
 appendfilename "appendonly.aof"
 appendfsync everysec
 auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
 aof-use-rdb-preamble yes
 
-# Performance tuning
 activerehashing yes
-lazyfree-lazy-eviction yes  # Added for better performance
-lazyfree-lazy-expire yes    # Added for better performance
-lazyfree-lazy-server-del yes  # Added for better performance
-replica-lazy-flush yes      # Added for better performance
+lazyfree-lazy-eviction yes
+lazyfree-lazy-expire yes
+lazyfree-lazy-server-del yes
+replica-lazy-flush yes
 
-# Memory management
-maxmemory-policy noeviction  # Added to prevent key eviction
+maxmemory-policy noeviction

--- a/redis.conf
+++ b/redis.conf
@@ -1,109 +1,36 @@
+# Network
 bind 127.0.0.1
 protected-mode yes
 port 6379
-
-tcp-backlog 511
-timeout 0
 tcp-keepalive 300
 
+# General
 daemonize no
-
 supervised no
-
-pidfile /var/run/redis_6379.pid
-
 loglevel notice
-logfile ""
 databases 16
 
-always-show-logo yes
-
-save 900 1
-save 300 10
-save 60 10000
-
-stop-writes-on-bgsave-error yes
-
-rdbcompression yes
-
-rdbchecksum yes
-
+# Persistence - RDB configuration
+save 900 1      # Save after 15 minutes if at least 1 key changed
+save 300 10     # Save after 5 minutes if at least 10 keys changed
+save 60 10000   # Save after 1 minute if at least 10000 keys changed
 dbfilename dump.rdb
+dir /data
 
-rdb-del-sync-files no
-
-dir /data/db
-replica-serve-stale-data yes
-
-replica-read-only yes
-
-repl-diskless-sync no
-
-repl-diskless-sync-delay 5
-
-repl-diskless-load disabled
-
-repl-disable-tcp-nodelay no
-
-replica-priority 100
-
-acllog-max-len 128
-
-lazyfree-lazy-eviction no
-lazyfree-lazy-expire no
-lazyfree-lazy-server-del no
-replica-lazy-flush no
-
-lazyfree-lazy-user-del no
-
-
-appendonly no
-
+# Persistence - AOF configuration
+appendonly yes  # Changed to YES to enable AOF persistence
 appendfilename "appendonly.aof"
-
 appendfsync everysec
-no-appendfsync-on-rewrite no
-
 auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
-
-aof-load-truncated yes
-
 aof-use-rdb-preamble yes
-lua-time-limit 5000
 
-slowlog-log-slower-than 10000
-
-slowlog-max-len 128
-
-latency-monitor-threshold 0
-
-notify-keyspace-events ""
-
-hash-max-ziplist-entries 512
-hash-max-ziplist-value 64
-
-list-max-ziplist-size -2
-
-list-compress-depth 0
-
-set-max-intset-entries 512
-
-zset-max-ziplist-entries 128
-zset-max-ziplist-value 64
-hll-sparse-max-bytes 3000
-
-stream-node-max-bytes 4096
-stream-node-max-entries 100
-
+# Performance tuning
 activerehashing yes
+lazyfree-lazy-eviction yes  # Added for better performance
+lazyfree-lazy-expire yes    # Added for better performance
+lazyfree-lazy-server-del yes  # Added for better performance
+replica-lazy-flush yes      # Added for better performance
 
-client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit replica 256mb 64mb 60
-client-output-buffer-limit pubsub 32mb 8mb 60
-
-hz 10
-dynamic-hz yes
-aof-rewrite-incremental-fsync yes
-rdb-save-incremental-fsync yes
-jemalloc-bg-thread yes
+# Memory management
+maxmemory-policy noeviction  # Added to prevent key eviction


### PR DESCRIPTION
This pull request updates the Redis configuration and the `docker-compose-mirage.yml` file to improve Redis performance, enable persistence, and align with newer Redis versions. Key changes include upgrading Redis to version 8.0.1, enabling AOF persistence, and optimizing Redis configuration for performance and reliability.

### Updates to `docker-compose-mirage.yml`:

* **Redis image upgrade**: Updated the Redis image from `redis:6.0.10-alpine` to `redis:8.0.1-alpine` for compatibility with the latest features and improvements.
* **Volume path adjustment**: Changed the Redis data volume mount path from `/data/db` to `/data` to align with the updated Redis configuration.
* **Restart policy**: Added a restart policy (`restart: unless-stopped`) for the Redis service to ensure it automatically restarts in case of failures.

### Updates to `redis.conf`:

* **Persistence enhancements**:
  - Enabled AOF persistence by setting `appendonly` to `yes` for improved data durability.
  - Updated RDB configuration to specify save intervals based on key changes.
* **Performance tuning**:
  - Enabled lazy-free options (`lazyfree-lazy-eviction`, `lazyfree-lazy-expire`, etc.) for better performance during key deletions.
  - Added `maxmemory-policy noeviction` to prevent unintentional key evictions.
* **General cleanup**: Removed deprecated or unnecessary configurations, such as `tcp-backlog`, `pidfile`, and others, to streamline the configuration file.