### PR TITLE
Add allowPreEIP155Txns and set skaleDisableChainIdCheck: true

### DIFF
--- a/fair_base_config.json
+++ b/fair_base_config.json
@@ -20,8 +20,9 @@
 		"difficultyBoundDivisor": "0x0800",
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
-		"skaleDisableChainIdCheck": true,
-		"getLogsBlocksLimit": 2000
+		"skaleDisableChainIdCheck": false,
+		"getLogsBlocksLimit": 2000,
+		"allowPreEIP155Txns": true
 	},
 	"unddos": {
 		"origins": [


### PR DESCRIPTION
This pull request modifies the `fair_base_config.json` file to update blockchain configuration settings. The key changes involve enabling support for pre-EIP-155 transactions and adjusting a chain ID check setting.

### Configuration updates:
* Changed `"skaleDisableChainIdCheck"` from `true` to `false`, enabling chain ID checks.
* Added `"allowPreEIP155Txns": true`, permitting transactions that predate EIP-155.