### PR TITLE
Update node params for FAIR Testnet

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -21,6 +21,7 @@ services:
       SGX_URL: ${SGX_SERVER_URL}
       ENDPOINT: ${ENDPOINT}
       BOOT_ENDPOINT: ${BOOT_ENDPOINT}
+      GAS_MULTIPLIER: 2
     volumes:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -92,10 +92,10 @@ envs:
       maxCacheSize: 16000000
       collectionQueueSize: 20
       collectionDuration: 60
-      transactionQueueSize: 1000
+      transactionQueueSize: 12800
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
-      maxOpenLeveldbFiles: 1000
+      maxOpenLeveldbFiles: 4000
 
     info:
       chain_id: "0x3A7"


### PR DESCRIPTION
This pull request increases the capacity for transaction processing and database file handling in the `fair_static_params.yaml` configuration. These changes are aimed at improving system throughput and scalability.

Configuration capacity increases:

* Increased `transactionQueueSize` from 1,000 to 12,800 to allow the system to queue more transactions at once, which can help handle higher transaction loads.
* Increased `maxOpenLeveldbFiles` from 1,000 to 4,000 to enable the system to open more LevelDB files simultaneously, supporting larger datasets and reducing file contention.