### PR TITLE
Update skaled version to 4.1.0-develop.43.1-fair-relwithdebinfo

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.43-mirage",
+    "version": "4.1.0-develop.43.1-fair-relwithdebinfo",
     "custom_args": {
       "ulimits_list": [
         {


### PR DESCRIPTION
This pull request makes a minor update to the `containers.json` file, specifically updating the version of the `skalenetwork/schain` container image to a new development release. 

* Updated the `skalenetwork/schain` container version from `4.1.0-develop.43-mirage` to `4.1.0-develop.43.1-fair-relwithdebinfo` in `containers.json`.