### PR TITLE
Set testnet_reward_activation_address

### DIFF
--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -50,7 +50,7 @@ envs:
     info:
       chain_id: "0x3A6"
       chain_name: fair
-      testnet_activation_address: false
+      testnet_reward_activation_address: false
 
   testnet:
     server:
@@ -100,7 +100,7 @@ envs:
     info:
       chain_id: "0x3A7"
       chain_name: fair-testnet
-      testnet_activation_address: true
+      testnet_reward_activation_address: true
 
   qanet:
     server:
@@ -150,7 +150,7 @@ envs:
     info:
       chain_id: "0x3A9"
       chain_name: fair-qa
-      testnet_activation_address: true
+      testnet_reward_activation_address: true
 
   devnet:
     server:
@@ -201,4 +201,4 @@ envs:
     info:
       chain_id: "0x3A8"
       chain_name: fair-devnet1
-      testnet_activation_address: true
+      testnet_reward_activation_address: true

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -50,6 +50,7 @@ envs:
     info:
       chain_id: "0x3A6"
       chain_name: fair
+      testnet_activation_address: false
 
   testnet:
     server:
@@ -99,6 +100,7 @@ envs:
     info:
       chain_id: "0x3A7"
       chain_name: fair-testnet
+      testnet_activation_address: true
 
   qanet:
     server:
@@ -148,6 +150,7 @@ envs:
     info:
       chain_id: "0x3A9"
       chain_name: fair-qa
+      testnet_activation_address: true
 
   devnet:
     server:
@@ -198,3 +201,4 @@ envs:
     info:
       chain_id: "0x3A8"
       chain_name: fair-devnet1
+      testnet_activation_address: true


### PR DESCRIPTION
This pull request adds a new parameter, `testnet_activation_address`, to the `info` section for each environment in the `fair_static_params.yaml` file. This parameter indicates whether the environment is a testnet or not.

Configuration updates:

* Added `testnet_activation_address: false` to the `fair` (mainnet) environment to specify it is not a testnet.
* Added `testnet_activation_address: true` to the `fair-testnet`, `fair-qa`, and `fair-devnet1` environments to specify these are testnet environments. [[1]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R103) [[2]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R153) [[3]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R204)