### PR TITLE
Update TM. Increase log level to trace

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -14,7 +14,7 @@ services:
   transaction-manager:
     <<: *skale_base
     container_name: skale_transaction-manager
-    image: skalenetwork/transaction-manager:3.0.0
+    image: skalenetwork/transaction-manager:3.0.1-develop.0
     network_mode: host
     tty: true
     environment:

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -80,12 +80,12 @@ envs:
       maxConsensusStorageBytes: 30000000000
       constantGasPrice: 10000000000
 
-    skaled_cmd: ["-v 4", "--aa no"]
+    skaled_cmd: ["-v 3", "--aa no"]
 
     node:
       bindIP: "0.0.0.0"
-      logLevel: "trace"
-      logLevelConfig: "trace"
+      logLevel: "debug"
+      logLevelConfig: "debug"
       pg-threads: 10
       pg-threads-limit: 10
       minCacheSize: 8000000

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -80,7 +80,7 @@ envs:
       maxConsensusStorageBytes: 30000000000
       constantGasPrice: 10000000000
 
-    skaled_cmd: ["-v 3", "--aa no"]
+    skaled_cmd: ["-v 2", "--aa no"]
 
     node:
       bindIP: "0.0.0.0"

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -80,12 +80,12 @@ envs:
       maxConsensusStorageBytes: 30000000000
       constantGasPrice: 10000000000
 
-    skaled_cmd: ["-v 2", "--aa no"]
+    skaled_cmd: ["-v 4", "--aa no"]
 
     node:
       bindIP: "0.0.0.0"
-      logLevel: "info"
-      logLevelConfig: "info"
+      logLevel: "trace"
+      logLevelConfig: "trace"
       pg-threads: 10
       pg-threads-limit: 10
       minCacheSize: 8000000


### PR DESCRIPTION
This pull request updates the configuration for the transaction manager and node logging in the Skale network setup. The main changes include upgrading the transaction manager image and increasing the verbosity of node logging for more detailed output.

**Transaction Manager Update:**
- Updated the `transaction-manager` service in `docker-compose-fair.yml` to use the `skalenetwork/transaction-manager:3.0.1-develop.0` image instead of `3.0.0`.

**Node Logging and Command Verbosity:**
- Increased the `skaled_cmd` log verbosity from `-v 2` to `-v 4` in `fair_static_params.yaml`.
- Changed the node's `logLevel` and `logLevelConfig` from `"info"` to `"trace"` for more granular logging output in `fair_static_params.yaml`.