### PR TITLE
Pass PASSIVE_NODE to watchdog

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   fair-boot:
     <<: *skale_base
     container_name: fair_boot_admin
-    image: skalenetwork/admin:3.1.0-fair.23
+    image: skalenetwork/admin:3.1.0-fair.24
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   fair-admin:
     <<: *skale_base
     container_name: fair_admin
-    image: skalenetwork/admin:3.1.0-fair.23
+    image: skalenetwork/admin:3.1.0-fair.24
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   fair-boot-api:
     <<: *skale_base
     container_name: fair_boot_api
-    image: skalenetwork/admin:3.1.0-fair.23
+    image: skalenetwork/admin:3.1.0-fair.24
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   fair-api:
     <<: *skale_base
     container_name: fair_api
-    image: skalenetwork/admin:3.1.0-fair.23
+    image: skalenetwork/admin:3.1.0-fair.24
     network_mode: host
     tty: true
     cap_add:
@@ -201,7 +201,7 @@ services:
   watchdog:
     <<: *skale_base
     container_name: skale_watchdog
-    image: skalenetwork/watchdog:3.0.0-develop.0
+    image: skalenetwork/watchdog:3.0.1-develop.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -208,6 +208,7 @@ services:
       FLASK_APP_HOST: "127.0.0.1"
       FLASK_DEBUG_MODE: "False"
       SKALE_NETWORK_TYPE: "fair"
+      PASSIVE_NODE: ${PASSIVE_NODE}
 
   nginx:
     <<: *skale_base

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -21,6 +21,7 @@ services:
       SGX_URL: ${SGX_SERVER_URL}
       ENDPOINT: ${ENDPOINT}
       BOOT_ENDPOINT: ${BOOT_ENDPOINT}
+      CONFIRMATION_BLOCKS: 0
     volumes:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data


### PR DESCRIPTION
This pull request makes a small update to the `docker-compose-fair.yml` configuration by introducing a new environment variable.

- Added the `PASSIVE_NODE` environment variable to the service configuration, allowing it to be set dynamically via environment substitution.