### PR TITLE
Update filebeat rename containers

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,5 +1,5 @@
 {
-  "schain": {
+  "skaled": {
     "name": "skalenetwork/schain",
     "version": "4.1.0-develop.47-mirage",
     "custom_args": {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -1,5 +1,5 @@
 services:
-  base: &skale_base
+  base: &sk_base
     image: rancher/pause:3.6
     restart: unless-stopped
     labels:
@@ -12,8 +12,8 @@ services:
         max-size: "10m"
 
   transaction-manager:
-    <<: *skale_base
-    container_name: skale_transaction-manager
+    <<: *sk_base
+    container_name: sk_tm
     image: skalenetwork/transaction-manager:3.0.0-beta.1
     network_mode: host
     tty: true
@@ -26,9 +26,9 @@ services:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data
 
-  fair-boot:
-    <<: *skale_base
-    container_name: fair_boot_admin
+  boot-admin:
+    <<: *sk_base
+    container_name: sk_boot_admin
     image: skalenetwork/admin:3.1.0-fair.24
     cpu_shares: 192
     network_mode: host
@@ -69,9 +69,9 @@ services:
       retries: 2
       start_period: 30s
 
-  fair-admin:
-    <<: *skale_base
-    container_name: fair_admin
+  admin:
+    <<: *sk_base
+    container_name: sk_admin
     image: skalenetwork/admin:3.1.0-fair.24
     cpu_shares: 192
     network_mode: host
@@ -112,9 +112,9 @@ services:
       retries: 2
       start_period: 30s
 
-  fair-boot-api:
-    <<: *skale_base
-    container_name: fair_boot_api
+  boot-api:
+    <<: *sk_base
+    container_name: sk_boot_api
     image: skalenetwork/admin:3.1.0-fair.24
     network_mode: host
     tty: true
@@ -148,9 +148,9 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
 
-  fair-api:
-    <<: *skale_base
-    container_name: fair_api
+  api:
+    <<: *sk_base
+    container_name: sk_api
     image: skalenetwork/admin:3.1.0-fair.24
     network_mode: host
     tty: true
@@ -185,8 +185,8 @@ services:
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
 
   redis:
-    <<: *skale_base
-    container_name: skale_redis
+    <<: *sk_base
+    container_name: sk_redis
     image: "redis:8.0.1-alpine"
     network_mode: host
     tty: true
@@ -199,8 +199,8 @@ services:
     restart: unless-stopped
 
   watchdog:
-    <<: *skale_base
-    container_name: skale_watchdog
+    <<: *sk_base
+    container_name: sk_watchdog
     image: skalenetwork/watchdog:3.0.1-develop.0
     network_mode: host
     environment:
@@ -212,9 +212,9 @@ services:
       PASSIVE_NODE: ${PASSIVE_NODE}
 
   nginx:
-    <<: *skale_base
+    <<: *sk_base
     image: nginx:1.20.2
-    container_name: skale_nginx
+    container_name: sk_nginx
     network_mode: host
     depends_on:
       - watchdog
@@ -229,7 +229,7 @@ services:
         read_only: true
 
   advisor:
-    <<: *skale_base
+    <<: *sk_base
     image: gcr.io/cadvisor/cadvisor-amd64:v0.50.0
     container_name: monitor_cadvisor
     cpu_shares: 128
@@ -242,7 +242,7 @@ services:
       - /dev/disk/:/dev/disk:ro
 
   node-exporter:
-    <<: *skale_base
+    <<: *sk_base
     container_name: monitor_node_exporter
     image: quay.io/prometheus/node-exporter
     volumes:
@@ -257,10 +257,10 @@ services:
     network_mode: host
 
   filebeat:
-    <<: *skale_base
-    container_name: skale_filebeat
+    <<: *sk_base
+    container_name: sk_filebeat
     user: root
-    image: docker.elastic.co/beats/filebeat:7.3.1
+    image: elastic/filebeat:9.1.3
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 services:
-  base: &skale_base
+  base: &sk_base
     image: rancher/pause:3.6
     restart: unless-stopped
     labels:
@@ -13,9 +13,9 @@ services:
         max-file: "5"
         max-size: "10m"
 
-  skale-passive-admin:
-    <<: *skale_base
-    container_name: skale_passive_admin
+  admin:
+    <<: *sk_base
+    container_name: sk_admin
     image: skalenetwork/admin:2.10.0-beta.1
     network_mode: host
     tty: true
@@ -48,9 +48,9 @@ services:
       start_period: 30s
 
   nginx:
-    <<: *skale_base
+    <<: *sk_base
     image: nginx:1.20.2
-    container_name: skale_nginx
+    container_name: sk_nginx
     network_mode: host
     volumes:
       - ${SKALE_DIR}/node_data/nginx.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 services:
-  base: &skale_base
+  base: &sk_base
     image: rancher/pause:3.6
     restart: unless-stopped
     labels:
@@ -14,8 +14,8 @@ services:
         max-size: "10m"
 
   transaction-manager:
-    <<: *skale_base
-    container_name: skale_transaction-manager
+    <<: *sk_base
+    container_name: sk_tm
     image: skalenetwork/transaction-manager:2.3.0
     network_mode: host
     tty: true
@@ -26,9 +26,9 @@ services:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data
 
-  skale-admin:
-    <<: *skale_base
-    container_name: skale_admin
+  admin:
+    <<: *sk_base
+    container_name: sk_admin
     image: skalenetwork/admin:2.10.2-fair-beta.0
     cpu_shares: 192
     network_mode: host
@@ -70,9 +70,9 @@ services:
       retries: 2
       start_period: 30s
 
-  skale-api:
-    <<: *skale_base
-    container_name: skale_api
+  api:
+    <<: *sk_base
+    container_name: sk_api
     image: skalenetwork/admin:2.10.2-fair-beta.0
     network_mode: host
     tty: true
@@ -107,7 +107,7 @@ services:
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
 
   celery:
-    <<: *skale_base
+    <<: *sk_base
     container_name: celery
     image: skalenetwork/admin:2.10.2-fair-beta.0
     network_mode: host
@@ -122,8 +122,8 @@ services:
       - /var/run/skale:/var/run/skale
 
   redis:
-    <<: *skale_base
-    container_name: skale_redis
+    <<: *sk_base
+    container_name: sk_redis
     image: "redis:6.0.10-alpine"
     network_mode: host
     tty: true
@@ -135,8 +135,8 @@ services:
       - ${SKALE_DIR}/config/redis.conf:/data/redis.conf
 
   bounty:
-    <<: *skale_base
-    container_name: skale_bounty
+    <<: *sk_base
+    container_name: sk_bounty
     image: skalenetwork/bounty-agent:2.2.0-stable.0
     network_mode: host
     environment:
@@ -154,8 +154,8 @@ services:
       - ${SKALE_DIR}/node_data:/skale_node_data
 
   watchdog:
-    <<: *skale_base
-    container_name: skale_watchdog
+    <<: *sk_base
+    container_name: sk_watchdog
     image: skalenetwork/watchdog:2.2.0-stable.0
     network_mode: host
     environment:
@@ -165,9 +165,9 @@ services:
       FLASK_DEBUG_MODE: "False"
 
   nginx:
-    <<: *skale_base
+    <<: *sk_base
     image: nginx:1.20.2
-    container_name: skale_nginx
+    container_name: sk_nginx
     network_mode: host
     depends_on:
       - watchdog
@@ -183,7 +183,7 @@ services:
         read_only: true
 
   advisor:
-    <<: *skale_base
+    <<: *sk_base
     image: gcr.io/cadvisor/cadvisor-amd64:v0.50.0
     container_name: monitor_cadvisor
     cpu_shares: 128
@@ -196,7 +196,7 @@ services:
       - /dev/disk/:/dev/disk:ro
 
   node-exporter:
-    <<: *skale_base
+    <<: *sk_base
     container_name: monitor_node_exporter
     image: quay.io/prometheus/node-exporter
     volumes:
@@ -211,10 +211,10 @@ services:
     network_mode: host
 
   filebeat:
-    <<: *skale_base
-    container_name: skale_filebeat
+    <<: *sk_base
+    container_name: sk_filebeat
     user: root
-    image: docker.elastic.co/beats/filebeat:7.3.1
+    image: elastic/filebeat:9.1.3
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -1,26 +1,28 @@
 filebeat.inputs:
-- type: container
-  paths:
-    - '/var/lib/docker/containers/*/*.log'
+  - type: filestream
+    id: docker-containers
+    paths:
+      - /var/lib/docker/containers/*/*.log
+    parsers:
+      - container:
+          stream: all
 
-- type: log
-  enabled: true
-  paths:
-    - '/var/log/docker-lvmpy/lvmpy.log'
+  - type: filestream
+    id: lvmpy-log
+    enabled: true
+    paths:
+      - /var/log/docker-lvmpy/lvmpy.log
 
 processors:
-- add_host_metadata:
-#    netinfo.enabled: false
-- add_docker_metadata:
-    host: "unix:///var/run/skale/docker.sock"
-- decode_json_fields:
-    fields: ["message", "log"]
-#    target: "json"
-    target: ""
-    overwrite_keys: true
+  - add_host_metadata: {}
+  - add_docker_metadata:
+      host: "unix:///var/run/skale/docker.sock"
+  - decode_json_fields:
+      fields: ["message"]
+      target: ""
+      overwrite_keys: true
 
 output.logstash:
-  hosts: ${FILEBEAT_HOST}
+  hosts: ["${FILEBEAT_HOST}"]
 
-logging.json: true
 logging.metrics.enabled: false

--- a/filebeat.yml.j2
+++ b/filebeat.yml.j2
@@ -7,11 +7,13 @@ filebeat.inputs:
       - container:
           stream: all
 
+  {% if is_skale_node|default(false) %}
   - type: filestream
     id: lvmpy-log
     enabled: true
     paths:
       - /var/log/docker-lvmpy/lvmpy.log
+  {% endif %}
 
 processors:
   - add_host_metadata: {}

--- a/filebeat.yml.j2
+++ b/filebeat.yml.j2
@@ -1,31 +1,33 @@
 filebeat.inputs:
-- type: container
-  paths:
-    - '/var/lib/docker/containers/*/*.log'
+  - type: filestream
+    id: docker-containers
+    paths:
+      - /var/lib/docker/containers/*/*.log
+    parsers:
+      - container:
+          stream: all
 
-- type: log
-  enabled: true
-  paths:
-    - '/var/log/docker-lvmpy/lvmpy.log'
+  - type: filestream
+    id: lvmpy-log
+    enabled: true
+    paths:
+      - /var/log/docker-lvmpy/lvmpy.log
 
 processors:
-- add_host_metadata:
-#    netinfo.enabled: false
-- add_docker_metadata:
-    host: "unix:///var/run/skale/docker.sock"
-- add_fields:
-    fields:
-      id: {{ id }}
-      ip: '{{ ip }}'
-      contract_address: '{{ contract_address }}'
-- decode_json_fields:
-    fields: ["message", "log"]
-#    target: "json"
-    target: ""
-    overwrite_keys: true
+  - add_host_metadata: {}
+  - add_docker_metadata:
+      host: "unix:///var/run/skale/docker.sock"
+  - add_fields:
+      fields:
+        id: {{ id }}
+        ip: '{{ ip }}'
+        contract_address: '{{ contract_address }}'
+  - decode_json_fields:
+      fields: ["message"]
+      target: ""
+      overwrite_keys: true
 
 output.logstash:
-  hosts: ${FILEBEAT_HOST}
+  hosts: ["${FILEBEAT_HOST}"]
 
-logging.json: true
 logging.metrics.enabled: false


### PR DESCRIPTION
This pull request standardizes service and container naming conventions across all Docker Compose files, updates Filebeat configuration to use the newer filestream input, and improves consistency in configuration files. The main changes are grouped below.

**Docker Compose Service and Container Naming Consistency:**

* Renamed the Docker Compose YAML anchor from `skale_base` to `sk_base` in all Compose files for consistency. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L2-R2) [[2]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L4-R4) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-R4)
* Updated all service and container names to use the `sk_` prefix instead of `skale_` or `fair_`, and unified service names (e.g., `skale_transaction-manager` → `sk_tm`, `skale_admin`/`fair_admin` → `sk_admin`, `skale_api`/`fair_api` → `sk_api`, etc.). [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L15-R16) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L29-R31) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L72-R74) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L115-R117) [[5]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L151-R153) [[6]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L188-R189) [[7]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L202-R203) [[8]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L215-R217) [[9]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L232-R232) [[10]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L245-R245) [[11]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L260-R263) [[12]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L16-R18) [[13]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L51-R53) [[14]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L17-R18) [[15]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R31) [[16]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L73-R75) [[17]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L110-R110) [[18]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L125-R126) [[19]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L138-R139) [[20]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L157-R158) [[21]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L168-R170) [[22]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L186-R186) [[23]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L199-R199) [[24]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L214-R217)

**Filebeat Configuration Modernization:**

* Migrated Filebeat input definitions from deprecated `container` and `log` types to the recommended `filestream` input in both `filebeat.yml` and `filebeat.yml.j2`, including improved parsing for Docker container logs. [[1]](diffhunk://#diff-ac549ee29f3b6218b119be5abfd37d57a6e6bacbc746e6395990c28ee0b2d955L2-L25) [[2]](diffhunk://#diff-286d6dbfdc37a9edbfc1d88b367af3beff353351e420ae09cfcbc79c783f1a83L2-R19)
* Updated the JSON decoding processor to only target the `message` field, and changed the Logstash output to use a list for hosts. [[1]](diffhunk://#diff-ac549ee29f3b6218b119be5abfd37d57a6e6bacbc746e6395990c28ee0b2d955L2-L25) [[2]](diffhunk://#diff-286d6dbfdc37a9edbfc1d88b367af3beff353351e420ae09cfcbc79c783f1a83L22-L30)

**Other Notable Changes:**

* Updated the Filebeat Docker image to `elastic/filebeat:9.1.3` (was `docker.elastic.co/beats/filebeat:7.3.1`). [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L260-R263) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L214-R217)
* Changed the container key in `containers.json` from `schain` to `skaled` to match the new naming convention.