### PR TITLE
Update container versions - FAIR Testnet v2

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.47-mirage",
+    "version": "4.1.0-develop.49-mirage",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -14,7 +14,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.0.0-beta.1
+    image: skalenetwork/transaction-manager:3.0.1-beta.0
     network_mode: host
     tty: true
     environment:
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.1.0-fair.24
+    image: skalenetwork/admin:3.1.0-fair-beta.6
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.1.0-fair.24
+    image: skalenetwork/admin:3.1.0-fair-beta.6
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.1.0-fair.24
+    image: skalenetwork/admin:3.1.0-fair-beta.6
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.1.0-fair.24
+    image: skalenetwork/admin:3.1.0-fair-beta.6
     network_mode: host
     tty: true
     cap_add:
@@ -201,7 +201,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.0.1-develop.0
+    image: skalenetwork/watchdog:3.0.1-beta.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300


### PR DESCRIPTION
This pull request updates several container image versions in the deployment configuration files to newer beta releases. The changes mainly focus on upgrading service images to improve stability, add new features, or incorporate recent fixes.

**Container image upgrades:**

* Upgraded `skalenetwork/schain` container image version from `4.1.0-develop.47-mirage` to `4.1.0-develop.49-mirage` in `containers.json`.

**Service image updates in `docker-compose-fair.yml`:**

* Updated `transaction-manager` image to `skalenetwork/transaction-manager:3.0.1-beta.0` (from `3.0.0-beta.1`).
* Updated multiple `admin`-related service images (`boot-admin`, `admin`, `boot-api`, `api`) to `skalenetwork/admin:3.1.0-fair-beta.6` (from `3.1.0-fair.24`). [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L118-R118) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L154-R154)
* Updated `watchdog` image to `skalenetwork/watchdog:3.0.1-beta.0` (from `3.0.1-develop.0`).