### PR TITLE
Update skaled params

### DIFF
--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -92,10 +92,10 @@ envs:
       maxCacheSize: 16000000
       collectionQueueSize: 20
       collectionDuration: 60
-      transactionQueueSize: 1000
+      transactionQueueSize: 12800
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
-      maxOpenLeveldbFiles: 1000
+      maxOpenLeveldbFiles: 3000
 
     info:
       chain_id: "0x3A7"


### PR DESCRIPTION
This pull request makes a configuration update to the `fair_static_params.yaml` file, increasing several resource limits to support higher throughput and scalability.

Resource limit increases:

* Increased `transactionQueueSize` from 1,000 to 12,800 to allow more transactions to be queued.
* Increased `maxOpenLeveldbFiles` from 1,000 to 3,000 to permit more LevelDB files to be opened simultaneously.