### PR TITLE
Update fair_static_params.yaml

### DIFF
--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -99,7 +99,7 @@ envs:
 
     info:
       chain_id: "0x3A7"
-      chain_name: fair-testnet
+      chain_name: fair-testnet2
       testnet_reward_activation_address: true
 
   qanet:


### PR DESCRIPTION
This pull request makes a minor update to the static parameters configuration. The change updates the chain name in the `info` section to reflect the new testnet environment.

* Updated `chain_name` from `fair-testnet` to `fair-testnet2` in the `envs:info` section of `fair_static_params.yaml`.