### PR TITLE
Update filebeat config - enable ssl

### DIFF
--- a/filebeat.yml
+++ b/filebeat.yml
@@ -24,5 +24,6 @@ processors:
 
 output.logstash:
   hosts: ["${FILEBEAT_HOST}"]
+  ssl.enabled: true
 
 logging.metrics.enabled: false

--- a/filebeat.yml.j2
+++ b/filebeat.yml.j2
@@ -31,5 +31,6 @@ processors:
 
 output.logstash:
   hosts: ["${FILEBEAT_HOST}"]
+  ssl.enabled: true
 
 logging.metrics.enabled: false


### PR DESCRIPTION
This pull request makes a small configuration update to the Filebeat output settings. The change enables SSL for connections to Logstash in both the `filebeat.yml` and `filebeat.yml.j2` files. This improves the security of data transmission between Filebeat and Logstash.

* Enabled SSL for Logstash output by adding `ssl.enabled: true` in both `filebeat.yml` and `filebeat.yml.j2` configuration files. [[1]](diffhunk://#diff-ac549ee29f3b6218b119be5abfd37d57a6e6bacbc746e6395990c28ee0b2d955R27) [[2]](diffhunk://#diff-286d6dbfdc37a9edbfc1d88b367af3beff353351e420ae09cfcbc79c783f1a83R34)