### PR TITLE
Update to Testnet V2 versions

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.49-mirage",
+    "version": "4.1.0-develop.52-mirage",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     network_mode: host
     tty: true
     cap_add:


### PR DESCRIPTION
This pull request updates container image versions for several services to ensure consistency and bring in the latest changes. The main updates are to the `skalenetwork/schain` and `skalenetwork/admin` images used across multiple services.

**Container image updates:**

* Updated the `skalenetwork/schain` container version from `4.1.0-develop.49-mirage` to `4.1.0-develop.52-mirage` in `containers.json` to use the latest build.

**Service image updates in `docker-compose-fair.yml`:**

* Changed the `skalenetwork/admin` image version from `3.1.0-fair-beta.6` to `3.1.0-fair-beta.7` for the following services:
  * `boot-admin`
  * `admin`
  * `boot-api`
  * `api`