### PR TITLE
Testnet V2 beta

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.49-mirage",
+    "version": "4.1.0-develop.52-mirage",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.1.0-fair-beta.6
+    image: skalenetwork/admin:3.1.0-fair-beta.7
     network_mode: host
     tty: true
     cap_add:

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -24,5 +24,6 @@ processors:
 
 output.logstash:
   hosts: ["${FILEBEAT_HOST}"]
+  ssl.enabled: true
 
 logging.metrics.enabled: false

--- a/filebeat.yml.j2
+++ b/filebeat.yml.j2
@@ -31,5 +31,6 @@ processors:
 
 output.logstash:
   hosts: ["${FILEBEAT_HOST}"]
+  ssl.enabled: true
 
 logging.metrics.enabled: false


### PR DESCRIPTION
This pull request updates several container image versions and enhances the security of the Filebeat log forwarding configuration by enabling SSL. The most important changes are grouped below by theme.

**Container image updates:**

* Updated the `skalenetwork/schain` container version from `4.1.0-develop.49-mirage` to `4.1.0-develop.52-mirage` in `containers.json`.
* Updated the `skalenetwork/admin` image version from `3.1.0-fair-beta.6` to `3.1.0-fair-beta.7` for the `boot-admin`, `admin`, `boot-api`, and `api` services in `docker-compose-fair.yml`. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L118-R118) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L154-R154)

**Filebeat configuration improvements:**

* Enabled SSL for Logstash output in both `filebeat.yml` and its Jinja template `filebeat.yml.j2` to improve log forwarding security. [[1]](diffhunk://#diff-ac549ee29f3b6218b119be5abfd37d57a6e6bacbc746e6395990c28ee0b2d955R27) [[2]](diffhunk://#diff-286d6dbfdc37a9edbfc1d88b367af3beff353351e420ae09cfcbc79c783f1a83R34)