### PR TITLE
Update versions - beta

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.52-mirage",
+    "version": "4.1.0-develop.53-fair",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.7
+    image: skalenetwork/admin:3.1.0-fair-beta.8
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.7
+    image: skalenetwork/admin:3.1.0-fair-beta.8
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.1.0-fair-beta.7
+    image: skalenetwork/admin:3.1.0-fair-beta.8
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.1.0-fair-beta.7
+    image: skalenetwork/admin:3.1.0-fair-beta.8
     network_mode: host
     tty: true
     cap_add:


### PR DESCRIPTION
This pull request updates container image versions for several services to incorporate the latest changes and improvements. The most significant updates are version bumps for both the core `skalenetwork/schain` container and the `skalenetwork/admin` images used across multiple services.

Container version updates:

* Updated the `skalenetwork/schain` container version from `4.1.0-develop.52-mirage` to `4.1.0-develop.53-fair` in `containers.json`.

Admin service image updates:

* Updated the `skalenetwork/admin` image from `3.1.0-fair-beta.7` to `3.1.0-fair-beta.8` for the following services in `docker-compose-fair.yml`:
    - `boot-admin`
    - `admin`
    - `boot-api`
    - `api`