### PR TITLE
Update containers to stable

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.53-fair",
+    "version": "4.1.0-develop.54-fair",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -14,7 +14,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.0.1-beta.0
+    image: skalenetwork/transaction-manager:3.0.1
     network_mode: host
     tty: true
     environment:
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.8
+    image: skalenetwork/admin:3.1.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -63,7 +63,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: ["CMD", "python3", "healthchecks/admin.py"]
+      test: [ "CMD", "python3", "healthchecks/admin.py" ]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.1.0-fair-beta.8
+    image: skalenetwork/admin:3.1.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -106,7 +106,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: ["CMD", "python3", "healthchecks/admin.py"]
+      test: [ "CMD", "python3", "healthchecks/admin.py" ]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.1.0-fair-beta.8
+    image: skalenetwork/admin:3.1.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.1.0-fair-beta.8
+    image: skalenetwork/admin:3.1.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -201,7 +201,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.0.1-beta.0
+    image: skalenetwork/watchdog:3.0.1-stable.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300


### PR DESCRIPTION
This pull request updates several service images in the `docker-compose-fair.yml` file to use stable releases instead of beta versions. These changes ensure that the deployment uses more reliable and production-ready images across multiple services.

**Image version updates:**

* Upgraded `transaction-manager` service image from `3.0.1-beta.0` to the stable `3.0.1` release.
* Upgraded `watchdog` service image from `3.0.1-beta.0` to the stable `3.0.1-stable.0` release.

**Admin-related services:**

* Updated the `admin`, `boot-admin`, `boot-api`, and `api` service images from `3.1.0-fair-beta.8` to the stable `3.1.0-fair-stable.1` release. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L118-R118) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L154-R154)