### PR TITLE
Fair to fair beta

### DIFF
--- a/fair_base_config.json
+++ b/fair_base_config.json
@@ -20,9 +20,9 @@
 		"difficultyBoundDivisor": "0x0800",
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
-		"skaleDisableChainIdCheck": false,
+		"skaleDisableChainIdCheck": true,
 		"getLogsBlocksLimit": 2000,
-		"allowPreEIP155Txns": false
+		"allowPreEIP155Txns": true
 	},
 	"unddos": {
 		"origins": [


### PR DESCRIPTION
This pull request makes two configuration changes to `fair_base_config.json` to relax certain network restrictions. These changes are likely intended to improve compatibility or facilitate testing.

Network configuration updates:

* Set `skaleDisableChainIdCheck` to `true`, disabling the chain ID check for Skale, which can help with interoperability or testing scenarios.
* Set `allowPreEIP155Txns` to `true`, allowing transactions that do not comply with EIP-155, which may be necessary for legacy transaction support.