### PR TITLE
Update versions: redis, nginx, filebeat

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -64,7 +64,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -107,7 +107,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -188,7 +188,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:8.0.1-alpine"
+    image: "redis:8.2.2-alpine"
     network_mode: host
     tty: true
     environment:
@@ -214,7 +214,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.20.2
+    image: nginx:1.29.1
     container_name: sk_nginx
     network_mode: host
     depends_on:
@@ -251,17 +251,17 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:
     <<: *sk_base
     container_name: sk_filebeat
     user: root
-    image: elastic/filebeat:9.1.3
+    image: elastic/filebeat:9.1.5
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   base: &sk_base
     image: rancher/pause:3.6
@@ -49,7 +47,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.20.2
+    image: nginx:1.29.1
     container_name: sk_nginx
     network_mode: host
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   base: &sk_base
     image: rancher/pause:3.6
@@ -166,7 +164,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.20.2
+    image: nginx:1.29.1
     container_name: sk_nginx
     network_mode: host
     depends_on:
@@ -204,17 +202,17 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:
     <<: *sk_base
     container_name: sk_filebeat
     user: root
-    image: elastic/filebeat:9.1.3
+    image: elastic/filebeat:9.1.5
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}


### PR DESCRIPTION
This pull request updates several Docker Compose files to use newer versions of key service images and improves consistency in command formatting. The main changes are version bumps for `nginx`, `redis`, and `filebeat` images, as well as minor formatting adjustments to command arguments. These updates help ensure the environment uses the latest stable releases and maintain uniformity across configuration files.

**Service image upgrades:**

* Updated `nginx` image from `1.20.2` to `1.29.1` in `docker-compose.yml`, `docker-compose-fair.yml`, and `docker-compose-passive.yml` for improved security and features. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L169-R167) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L217-R217) [[3]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L52-R50)
* Updated `redis` image from `8.0.1-alpine` to `8.2.2-alpine` in `docker-compose-fair.yml`.
* Updated `filebeat` image from `9.1.3` to `9.1.5` in `docker-compose.yml` and `docker-compose-fair.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L207-R215) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L254-R264)

**Configuration and formatting improvements:**

* Changed command argument formatting in `docker-compose.yml` and `docker-compose-fair.yml` from single quotes to double quotes for consistency. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L207-R215) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L254-R264)

**Other changes:**

* Removed the `version: '3.4'` line from the top of `docker-compose.yml` and `docker-compose-passive.yml` to align with newer Docker Compose practices. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-L2) [[2]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L1-L2)