### PR TITLE
Update admin version - 2.10.3

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: "3.4"
 
 services:
   base: &skale_base
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.10.2
+    image: skalenetwork/admin:2.10.3
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: "3.4"
 
 services:
   base: &skale_base
@@ -29,7 +29,7 @@ services:
   skale-admin:
     <<: *skale_base
     container_name: skale_admin
-    image: skalenetwork/admin:2.10.2
+    image: skalenetwork/admin:2.10.3
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   skale-api:
     <<: *skale_base
     container_name: skale_api
-    image: skalenetwork/admin:2.10.2
+    image: skalenetwork/admin:2.10.3
     network_mode: host
     tty: true
     cap_add:
@@ -105,7 +105,7 @@ services:
   celery:
     <<: *skale_base
     container_name: celery
-    image: skalenetwork/admin:2.10.2
+    image: skalenetwork/admin:2.10.3
     network_mode: host
     tty: true
     environment:
@@ -198,10 +198,10 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:


### PR DESCRIPTION
This pull request updates the Docker Compose configuration files to use the latest `skalenetwork/admin:2.10.3` image for all relevant services and standardizes YAML formatting. These changes ensure that all services run the updated image version and improve consistency in the configuration files.

**Image version updates:**

* Updated the `skalenetwork/admin` image version from `2.10.2` to `2.10.3` for the following services in `docker-compose.yml`: `skale-admin`, `skale-api`, and `celery`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L32-R32) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L74-R74) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L108-R108)
* Updated the `skalenetwork/admin` image version from `2.10.2` to `2.10.3` for the `skale-sync-admin` service in `docker-compose-sync.yml`.

**Formatting and consistency improvements:**

* Standardized YAML quotes for the `version` field in both `docker-compose.yml` and `docker-compose-sync.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R1) [[2]](diffhunk://#diff-a1ad93ebb84d01796df67ea264a7fb4adc69a6447063f28ce465312a38269d52L1-R1)
* Standardized command argument quoting in the `node-exporter` service in `docker-compose.yml` for improved YAML consistency.