### PR TITLE
Update container versions - fair testnet 0.2.4, replace rancher/pause

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -1,20 +1,19 @@
-services:
-  base: &sk_base
-    image: rancher/pause:3.6
-    restart: unless-stopped
-    labels:
-      com.skale.prefix: "node"
-    cpu_shares: 128
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
+x-sk-base: &sk_base
+  restart: unless-stopped
+  labels:
+    com.skale.prefix: "node"
+  cpu_shares: 128
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
 
+services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.0.1
+    image: skalenetwork/transaction-manager:3.1.0-beta.0
     network_mode: host
     tty: true
     environment:
@@ -30,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -64,7 +63,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -73,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -107,7 +106,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -116,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -152,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -202,7 +201,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.0.1-stable.0
+    image: skalenetwork/watchdog:3.1.0-beta.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300
@@ -251,10 +250,10 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -1,18 +1,15 @@
-version: '3.4'
+x-sk-base: &sk_base
+  restart: unless-stopped
+  labels:
+    com.skale.prefix: "node"
+  cpu_shares: 128
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
 
 services:
-  base: &sk_base
-    image: rancher/pause:3.6
-    restart: unless-stopped
-    labels:
-      com.skale.prefix: "node"
-    cpu_shares: 128
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
-
   admin:
     <<: *sk_base
     container_name: sk_admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,19 @@
-version: '3.4'
+x-sk-base: &sk_base
+  restart: unless-stopped
+  labels:
+    com.skale.prefix: "node"
+  cpu_shares: 128
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
 
 services:
-  base: &sk_base
-    image: rancher/pause:3.6
-    restart: unless-stopped
-    labels:
-      com.skale.prefix: "node"
-    cpu_shares: 128
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
-
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:2.3.0
+    image: skalenetwork/transaction-manager:3.1.0-beta.0
     network_mode: host
     tty: true
     environment:
@@ -156,7 +153,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:2.2.0-stable.0
+    image: skalenetwork/watchdog:3.1.0-beta.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300
@@ -204,10 +201,10 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:


### PR DESCRIPTION
This pull request updates the Docker Compose files to use newer, beta versions of several SKALE service images and makes minor improvements to the YAML structure and formatting. The changes ensure consistency across different deployment files and prepare the stack for the upcoming beta releases.

**Image version upgrades:**

* Updated the `transaction-manager` service image to `skalenetwork/transaction-manager:3.1.0-beta.0` in both `docker-compose.yml` and `docker-compose-fair.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R12-R16) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1R12-R16)
* Updated the `watchdog` service image to `skalenetwork/watchdog:3.1.0-beta.0` in both `docker-compose.yml` and `docker-compose-fair.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L159-R156) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L205-R204)
* Updated the `admin`, `boot-admin`, `boot-api`, and `api` service images to `skalenetwork/admin:3.2.0-fair-beta.0` in `docker-compose-fair.yml`. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L33-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L76-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L119-R118) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L155-R154)

**YAML structure and formatting improvements:**

* Changed the definition of the base service from a `base` service to an anchor named `sk_base` (`x-sk-base: &sk_base`) in all Compose files, and moved the `services:` key to the correct location. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L1-R1) [[2]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L1-R1) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R1) [[4]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6R12)
* Standardized the quoting style for command arguments in the `node-exporter` service for consistency. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L254-R256) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L207-R207)