### PR TITLE
Update versions - fair 0.2.4 stable

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.1.0-beta.0
+    image: skalenetwork/transaction-manager:3.1.0
     network_mode: host
     tty: true
     environment:
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     cap_add:
@@ -201,7 +201,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-beta.0
+    image: skalenetwork/watchdog:3.1.0-stable.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.1.0-beta.0
+    image: skalenetwork/transaction-manager:3.1.0
     network_mode: host
     tty: true
     environment:
@@ -153,7 +153,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-beta.0
+    image: skalenetwork/watchdog:3.1.0-stable.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300


### PR DESCRIPTION
This pull request updates several service images in both `docker-compose-fair.yml` and `docker-compose.yml` to use stable releases instead of beta versions. This change improves reliability and ensures the services are running on officially supported versions.

**Image version upgrades:**

* Upgraded `transaction-manager` service image to version `3.1.0` in both `docker-compose-fair.yml` and `docker-compose.yml`, replacing the previous beta version. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L16-R16) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-R16)
* Upgraded `watchdog` service image to version `3.1.0-stable.0` in both `docker-compose-fair.yml` and `docker-compose.yml`. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L204-R204) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L156-R156)

**Admin service image updates (fair compose file only):**

* Upgraded `boot-admin`, `admin`, `boot-api`, and `api` service images in `docker-compose-fair.yml` to `3.2.0-fair-stable.0`, replacing the previous beta versions. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L118-R118) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L154-R154)