### PR TITLE
Fair beta to fair stable

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -64,7 +64,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -107,7 +107,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -188,7 +188,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:8.0.1-alpine"
+    image: "redis:8.2.2-alpine"
     network_mode: host
     tty: true
     environment:
@@ -214,7 +214,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.20.2
+    image: nginx:1.29.1
     container_name: sk_nginx
     network_mode: host
     depends_on:
@@ -251,17 +251,17 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:
     <<: *sk_base
     container_name: sk_filebeat
     user: root
-    image: elastic/filebeat:9.1.3
+    image: elastic/filebeat:9.1.5
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.1.0-beta.0
+    image: skalenetwork/transaction-manager:3.1.0
     network_mode: host
     tty: true
     environment:
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     cap_add:
@@ -201,7 +201,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-beta.0
+    image: skalenetwork/watchdog:3.1.0-stable.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -1,20 +1,19 @@
-services:
-  base: &sk_base
-    image: rancher/pause:3.6
-    restart: unless-stopped
-    labels:
-      com.skale.prefix: "node"
-    cpu_shares: 128
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
+x-sk-base: &sk_base
+  restart: unless-stopped
+  labels:
+    com.skale.prefix: "node"
+  cpu_shares: 128
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
 
+services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.0.1
+    image: skalenetwork/transaction-manager:3.1.0-beta.0
     network_mode: host
     tty: true
     environment:
@@ -30,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -64,7 +63,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -73,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -107,7 +106,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: [ "CMD", "python3", "healthchecks/admin.py" ]
+      test: ["CMD", "python3", "healthchecks/admin.py"]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -116,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -152,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.1.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -202,7 +201,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.0.1-stable.0
+    image: skalenetwork/watchdog:3.1.0-beta.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300
@@ -251,10 +250,10 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-beta.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-beta.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-beta.1
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-beta.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   base: &sk_base
     image: rancher/pause:3.6
@@ -49,7 +47,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.20.2
+    image: nginx:1.29.1
     container_name: sk_nginx
     network_mode: host
     volumes:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -1,18 +1,15 @@
-version: '3.4'
+x-sk-base: &sk_base
+  restart: unless-stopped
+  labels:
+    com.skale.prefix: "node"
+  cpu_shares: 128
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
 
 services:
-  base: &sk_base
-    image: rancher/pause:3.6
-    restart: unless-stopped
-    labels:
-      com.skale.prefix: "node"
-    cpu_shares: 128
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
-
   admin:
     <<: *sk_base
     container_name: sk_admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.1.0-beta.0
+    image: skalenetwork/transaction-manager:3.1.0
     network_mode: host
     tty: true
     environment:
@@ -153,7 +153,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-beta.0
+    image: skalenetwork/watchdog:3.1.0-stable.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,19 @@
-version: '3.4'
+x-sk-base: &sk_base
+  restart: unless-stopped
+  labels:
+    com.skale.prefix: "node"
+  cpu_shares: 128
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
 
 services:
-  base: &sk_base
-    image: rancher/pause:3.6
-    restart: unless-stopped
-    labels:
-      com.skale.prefix: "node"
-    cpu_shares: 128
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
-
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:2.3.0
+    image: skalenetwork/transaction-manager:3.1.0-beta.0
     network_mode: host
     tty: true
     environment:
@@ -156,7 +153,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:2.2.0-stable.0
+    image: skalenetwork/watchdog:3.1.0-beta.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300
@@ -204,10 +201,10 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   base: &sk_base
     image: rancher/pause:3.6
@@ -166,7 +164,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.20.2
+    image: nginx:1.29.1
     container_name: sk_nginx
     network_mode: host
     depends_on:
@@ -204,17 +202,17 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:
     <<: *sk_base
     container_name: sk_filebeat
     user: root
-    image: elastic/filebeat:9.1.3
+    image: elastic/filebeat:9.1.5
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}


### PR DESCRIPTION
This pull request updates the Docker Compose files (`docker-compose.yml`, `docker-compose-fair.yml`, and `docker-compose-passive.yml`) to use newer versions of several container images and makes some minor structural and formatting improvements. The main focus is on upgrading service images for improved stability, security, and feature support.

**Key changes:**

**Service image upgrades:**

- Updated `transaction-manager` to version `3.1.0` in both `docker-compose.yml` and `docker-compose-fair.yml` for improved functionality and compatibility. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R12-R16) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1R12-R16)
- Upgraded `skalenetwork/admin` image from `3.1.0-fair-stable.1` to `3.2.0-fair-stable.0` for `boot-admin`, `admin`, `boot-api`, and `api` services in `docker-compose-fair.yml`. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L33-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L76-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L119-R118) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L155-R154)
- Updated `watchdog` to version `3.1.0-stable.0` in both `docker-compose.yml` and `docker-compose-fair.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L159-R156) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L205-R204)
- Bumped `redis` image to `8.2.2-alpine` in `docker-compose-fair.yml`.
- Upgraded `nginx` to version `1.29.1` in all Compose files for improved security and features. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L169-R166) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L217-R216) [[3]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L52-R49)
- Updated `elastic/filebeat` to `9.1.5` in both `docker-compose.yml` and `docker-compose-fair.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L207-R214) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L254-R263)

**Structural and formatting improvements:**

- Changed the Compose file structure to move the `sk_base` anchor to the top-level with the key `x-sk-base`, and removed the explicit `image: rancher/pause:3.6` from the base definition. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R1) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L1-R1) [[3]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L1-R1)
- Adjusted the YAML formatting for command arguments in the `node-exporter` service to use double quotes for consistency. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L207-R214) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L254-R263)
- Moved the `services:` key to the correct location after logging configuration in all Compose files for better YAML structure. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R12-R16) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1R12-R16) [[3]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6R12)