### PR TITLE
Update skale versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:2.10.2-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -70,7 +70,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:2.10.2-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     cap_add:
@@ -106,7 +106,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:2.10.2-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     environment:
@@ -121,7 +121,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:6.0.10-alpine"
+    image: "redis:8.2.2-alpine"
     network_mode: host
     tty: true
     environment:


### PR DESCRIPTION
This pull request updates the Docker images used for several services in the `docker-compose.yml` file to ensure the stack uses newer, stable versions. The most important changes are version bumps for the `skalenetwork/admin` and `redis` images across different services.

**Image version upgrades:**

* Updated the `admin`, `api`, and `celery` services to use the `skalenetwork/admin:3.2.0-fair-stable.0` image instead of the older `2.10.2-fair-beta.0` version. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R29) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L73-R73) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L109-R109)
* Updated the `redis` service to use the `redis:8.2.2-alpine` image instead of `redis:6.0.10-alpine`.