### PR TITLE
Bump admin version

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -70,7 +70,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     cap_add:
@@ -106,7 +106,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     environment:


### PR DESCRIPTION
This pull request updates the Docker images used for several services in both `docker-compose-fair.yml` and `docker-compose.yml` files. The main change is upgrading the `skalenetwork/admin` image from version `3.2.0-fair-stable.0` to `3.2.0-fair.3` for all relevant services. This ensures all services are running the latest fair release.

**Docker image version updates:**

* Updated `skalenetwork/admin` image version from `3.2.0-fair-stable.0` to `3.2.0-fair.3` for the following services in `docker-compose-fair.yml`:
  - `boot-admin`
  - `admin`
  - `boot-api`
  - `api`

* Updated `skalenetwork/admin` image version from `3.2.0-fair-stable.0` to `3.2.0-fair.3` for the following services in `docker-compose.yml`:
  - `admin`
  - `api`
  - `celery`