### PR TITLE
Update fair admin version, disable colors

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -97,6 +97,7 @@ services:
       FAIR_CONTRACTS: ${FAIR_CONTRACTS}
       SKALE_NETWORK_TYPE: "fair"
       PASSIVE_NODE: ${PASSIVE_NODE}
+      DISABLE_COLORS: "True"
 
     command: "python3 fair.py"
     volumes:
@@ -115,7 +116,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +152,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -13,7 +13,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:2.10.0-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -30,6 +30,7 @@ services:
       MAX_SCHAIN_FAILED_RPC_COUNT: 60
       MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
       IMA_CONTRACTS: ${IMA_CONTRACTS}
+      DISABLE_COLORS: "True"
     command: "python3 skale_passive.py"
     volumes:
       - /var/run/skale:/var/run/skale

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -53,6 +53,7 @@ services:
       INFLUX_URL: ${INFLUX_URL}
       MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
       IMA_CONTRACTS: ${IMA_CONTRACTS}
+      DISABLE_COLORS: "True"
 
     command: "python3 admin.py"
     volumes:
@@ -70,7 +71,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -106,7 +107,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     environment:


### PR DESCRIPTION
This pull request updates the Docker Compose configurations to use the latest stable version of the `skalenetwork/admin` image across all environments, and introduces an environment variable to disable colored output in service logs. These changes improve consistency and make log output more suitable for environments where colored text may be undesirable.

**Image version upgrades:**

* Updated the `skalenetwork/admin` image to `3.2.0-fair-stable.1` for all relevant services in `docker-compose.yml`, `docker-compose-fair.yml`, and `docker-compose-passive.yml`, replacing older or beta versions for `admin`, `api`, `boot-admin`, `boot-api`, and `celery` services. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L118-R119) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L154-R155) [[5]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L16-R16) [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R29) [[7]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L73-R74) [[8]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L109-R110)

**Environment variable additions:**

* Added the `DISABLE_COLORS: "True"` environment variable to the relevant services in all Docker Compose files to disable colored output in logs. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1R100) [[2]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6R33) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R56)