### PR TITLE
Fair to fair beta 0.2.5

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -115,7 +115,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +151,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -97,6 +97,7 @@ services:
       FAIR_CONTRACTS: ${FAIR_CONTRACTS}
       SKALE_NETWORK_TYPE: "fair"
       PASSIVE_NODE: ${PASSIVE_NODE}
+      DISABLE_COLORS: "True"
 
     command: "python3 fair.py"
     volumes:
@@ -115,7 +116,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -151,7 +152,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -13,7 +13,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:2.10.0-beta.1
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -30,6 +30,7 @@ services:
       MAX_SCHAIN_FAILED_RPC_COUNT: 60
       MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
       IMA_CONTRACTS: ${IMA_CONTRACTS}
+      DISABLE_COLORS: "True"
     command: "python3 skale_passive.py"
     volumes:
       - /var/run/skale:/var/run/skale

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -70,7 +70,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     cap_add:
@@ -106,7 +106,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair-stable.0
+    image: skalenetwork/admin:3.2.0-fair.3
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:2.10.2-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -70,7 +70,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:2.10.2-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     cap_add:
@@ -106,7 +106,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:2.10.2-fair-beta.0
+    image: skalenetwork/admin:3.2.0-fair-stable.0
     network_mode: host
     tty: true
     environment:
@@ -121,7 +121,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:6.0.10-alpine"
+    image: "redis:8.2.2-alpine"
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -53,6 +53,7 @@ services:
       INFLUX_URL: ${INFLUX_URL}
       MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
       IMA_CONTRACTS: ${IMA_CONTRACTS}
+      DISABLE_COLORS: "True"
 
     command: "python3 admin.py"
     volumes:
@@ -70,7 +71,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     cap_add:
@@ -106,7 +107,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair.3
+    image: skalenetwork/admin:3.2.0-fair-stable.1
     network_mode: host
     tty: true
     environment:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -78,7 +78,7 @@ envs:
         parallel-stormy-spica: 1723460400
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1728817200
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
@@ -181,7 +181,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 1721826000
       verifyBlsSyncPatchTimestamp: 1721829600
       externalGasPatchTimestamp: 1727712000
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
@@ -284,7 +284,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 0
       externalGasPatchTimestamp: 1727712000
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
@@ -389,7 +389,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1727353446
-      maxFeePerGasPatchTimestamp: 1741956440
+      invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000


### PR DESCRIPTION
This pull request updates several configuration files to use newer versions of container images and introduces a new environment variable for improved logging control. It also replaces a patch timestamp key in the `static_params.yaml` file to reflect a change in protocol or validation logic.

**Container image upgrades:**

* Updated all `skalenetwork/admin` service images in `docker-compose.yml`, `docker-compose-fair.yml`, and `docker-compose-passive.yml` to version `3.2.0-fair-stable.1`, ensuring consistency across environments and incorporating the latest stable features and fixes. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L118-R119) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L154-R155) [[5]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6L16-R16) [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R29) [[7]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L73-R74) [[8]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L109-R110)
* Upgraded the `redis` image in `docker-compose.yml` from `6.0.10-alpine` to `8.2.2-alpine` for improved performance and security.

**Environment variable additions:**

* Added `DISABLE_COLORS: "True"` to the environment variables of relevant services in all docker-compose files, likely to standardize log output and improve readability in certain environments. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1R100) [[2]](diffhunk://#diff-9def7d11e2bcee5975b738242b356e5c3a769c6e62fd2e1eee5def8c0e3719e6R33) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R56)

**Protocol/validation configuration update:**

* In `static_params.yaml`, replaced the `maxFeePerGasPatchTimestamp` key with `invalidTransactionFormatPatchTimestamp` in all relevant environments, indicating a shift in patch tracking or validation logic. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL81-R81) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL184-R184) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL287-R287) [[4]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL392-R392)