### PR TITLE
Fair beta to fair stable - 0.2.6

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -116,7 +116,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     network_mode: host
     tty: true
     cap_add:
@@ -152,7 +152,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -116,7 +116,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     network_mode: host
     tty: true
     cap_add:
@@ -152,7 +152,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -13,7 +13,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -13,7 +13,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     network_mode: host
     tty: true
     cap_add:
@@ -107,7 +107,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair-stable.1
+    image: skalenetwork/admin:3.2.0-fair.4
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     network_mode: host
     tty: true
     cap_add:
@@ -107,7 +107,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair.4
+    image: skalenetwork/admin:3.2.0-fair-stable.2
     network_mode: host
     tty: true
     environment:


### PR DESCRIPTION
This pull request updates the `skalenetwork/admin` Docker image version from `3.2.0-fair-stable.1` to `3.2.0-fair-stable.2` across all relevant services in the `docker-compose.yml`, `docker-compose-fair.yml`, and `docker-compose-passive.yml` files. This ensures all containers use the latest stable version of the admin image for improved consistency and potential bug fixes or enhancements.

**Docker image version updates:**

* Updated the `image` field for the `admin`, `api`, and `celery` services in `docker-compose.yml` to use `skalenetwork/admin:3.2.0-fair-stable.2` [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R29) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L74-R74) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L110-R110)
* Updated the `image` field for the `boot-admin`, `admin`, `boot-api`, and `api` services in `docker-compose-fair.yml` to use `skalenetwork/admin:3.2.0-fair-stable.2` [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L119-R119) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L155-R155)
* Updated the `image` field for the `admin` service in `docker-compose-passive.yml` to use `skalenetwork/admin:3.2.0-fair-stable.2`