### PR TITLE
2300 No self destruct

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.56-fair",
+    "version": "4.1.0-develop.60-fair",
     "custom_args": {
       "ulimits_list": [
         {

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -29,6 +29,7 @@ envs:
       snapshotDownloadInactiveTimeout: 120
       dbStorageLimit: 70000000000
       maxConsensusStorageBytes: 70000000000
+      disableSelfDestructPatchTimestamp: 1762773498
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -80,6 +81,7 @@ envs:
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
       constantGasPrice: 10000000000
+      disableSelfDestructPatchTimestamp: 1762773498
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -130,6 +132,7 @@ envs:
       snapshotDownloadInactiveTimeout: 120
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
+      disableSelfDestructPatchTimestamp: 1762273498
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -180,6 +183,7 @@ envs:
       snapshotDownloadInactiveTimeout: 120
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
+      disableSelfDestructPatchTimestamp: 1
 
     skaled_cmd:
       ["-v 3", "--web3-trace", "--enable-debug-behavior-apis", "--aa no"]


### PR DESCRIPTION
This pull request updates the `skaled` container version and introduces a new configuration parameter, `disableSelfDestructPatchTimestamp`, across multiple environments in `fair_static_params.yaml`. These changes help ensure the environments are aligned with the latest container release and introduce the ability to control the timing of the self-destruct patch feature.

Container version update:

* Updated the `skaled` container version from `4.1.0-develop.56-fair` to `4.1.0-develop.60-fair` in `containers.json`, ensuring the environments use the latest release.

Configuration changes for self-destruct patch timing:

* Added the `disableSelfDestructPatchTimestamp` parameter to several environment configurations in `fair_static_params.yaml`, allowing control over when the self-destruct patch is applied:
  * Set to `1762773498` for multiple environments. [[1]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R32) [[2]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R84)
  * Set to `1762273498` for one environment.
  * Set to `1` for another environment, likely to disable the patch immediately.