### PR TITLE
Separate redis mountpoints

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -195,8 +195,9 @@ services:
       - REDIS_REPLICATION_MODE=master
     command: "redis-server /data/redis.conf"
     volumes:
-      - ${SKALE_DIR}/node_data/redis-data:/data:rw
+      - ${SKALE_DIR}/node_data/redis-data:/data/db:rw
       - ${SKALE_DIR}/config/redis.conf:/data/redis.conf
+
     restart: unless-stopped
 
   watchdog:

--- a/redis.conf
+++ b/redis.conf
@@ -12,7 +12,7 @@ save 900 1
 save 300 10
 save 60 10000
 dbfilename dump.rdb
-dir /data
+dir /data/db
 
 appendonly yes
 appendfilename "appendonly.aof"


### PR DESCRIPTION
This pull request updates the Redis data directory configuration to improve data organization and consistency. The changes affect both the Docker Compose configuration and the Redis configuration file.

**Redis data directory changes:**

* Updated the Redis service volume mount in `docker-compose-fair.yml` to use `/data/db` as the data directory instead of `/data`, aligning it with the new directory structure.
* Changed the `dir` setting in `redis.conf` from `/data` to `/data/db` to match the new volume mount location and ensure Redis stores its data in the correct place.