### PR TITLE
Set disableSelfDestructPatchTimestamp for testnet, update skaled

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.61-fair",
+    "version": "4.1.0-develop.63-fair",
     "custom_args": {
       "ulimits_list": [
         {

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -81,7 +81,7 @@ envs:
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
       constantGasPrice: 10000000000
-      disableSelfDestructPatchTimestamp: 1762773498
+      disableSelfDestructPatchTimestamp: 1764158400
 
     skaled_cmd: ["-v 2", "--aa no"]
 


### PR DESCRIPTION
This pull request updates the configuration for the Skale Network container and modifies a static parameter related to a protocol patch. The main changes are version upgrades and a new timestamp for disabling the self-destruct patch.

Container version update:

* Upgraded the `skalenetwork/schain` container image version from `4.1.0-develop.61-fair` to `4.1.0-develop.63-fair` in `containers.json`.

Protocol configuration update:

* Changed the `disableSelfDestructPatchTimestamp` value in `fair_static_params.yaml` to `1764158400`, updating when the self-destruct patch is disabled.