### PR TITLE
Fair beta to fair stable - 0.2.7-fair

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.0-beta.1",
+    "version": "4.0.0-beta.2",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.0-beta.2",
+    "version": "4.0.0",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.56-fair",
+    "version": "4.1.0-develop.60-fair",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.60-fair",
+    "version": "4.1.0-develop.61-fair",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.1",
+    "version": "4.0.2-develop.0",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.61-fair",
+    "version": "4.1.0-develop.63-fair",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.0-beta.0",
+    "version": "4.0.0-beta.1",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -195,8 +195,9 @@ services:
       - REDIS_REPLICATION_MODE=master
     command: "redis-server /data/redis.conf"
     volumes:
-      - ${SKALE_DIR}/node_data/redis-data:/data:rw
+      - ${SKALE_DIR}/node_data/redis-data:/data/db:rw
       - ${SKALE_DIR}/config/redis.conf:/data/redis.conf
+
     restart: unless-stopped
 
   watchdog:

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -116,7 +116,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     network_mode: host
     tty: true
     cap_add:
@@ -152,7 +152,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -13,7 +13,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.10.0
+    image: skalenetwork/admin:2.10.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.10.1
+    image: skalenetwork/admin:2.10.2
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.10.0-beta.2
+    image: skalenetwork/admin:2.10.0
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.10.2
+    image: skalenetwork/admin:2.10.2-develop.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.10.0-beta.1
+    image: skalenetwork/admin:2.10.0-beta.2
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   skale-admin:
     <<: *skale_base
     container_name: skale_admin
-    image: skalenetwork/admin:2.10.0-beta.2
+    image: skalenetwork/admin:2.10.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   skale-api:
     <<: *skale_base
     container_name: skale_api
-    image: skalenetwork/admin:2.10.0-beta.2
+    image: skalenetwork/admin:2.10.0
     network_mode: host
     tty: true
     cap_add:
@@ -105,7 +105,7 @@ services:
   celery:
     <<: *skale_base
     container_name: celery
-    image: skalenetwork/admin:2.10.0-beta.2
+    image: skalenetwork/admin:2.10.0
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   skale-admin:
     <<: *skale_base
     container_name: skale_admin
-    image: skalenetwork/admin:2.10.1
+    image: skalenetwork/admin:2.10.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   skale-api:
     <<: *skale_base
     container_name: skale_api
-    image: skalenetwork/admin:2.10.1
+    image: skalenetwork/admin:2.10.2
     network_mode: host
     tty: true
     cap_add:
@@ -105,7 +105,7 @@ services:
   celery:
     <<: *skale_base
     container_name: celery
-    image: skalenetwork/admin:2.10.1
+    image: skalenetwork/admin:2.10.2
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     network_mode: host
     tty: true
     cap_add:
@@ -107,7 +107,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair-stable.2
+    image: skalenetwork/admin:3.2.0-fair.7
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   skale-admin:
     <<: *skale_base
     container_name: skale_admin
-    image: skalenetwork/admin:2.10.0-beta.1
+    image: skalenetwork/admin:2.10.0-beta.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   skale-api:
     <<: *skale_base
     container_name: skale_api
-    image: skalenetwork/admin:2.10.0-beta.1
+    image: skalenetwork/admin:2.10.0-beta.2
     network_mode: host
     tty: true
     cap_add:
@@ -105,7 +105,7 @@ services:
   celery:
     <<: *skale_base
     container_name: celery
-    image: skalenetwork/admin:2.10.0-beta.1
+    image: skalenetwork/admin:2.10.0-beta.2
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   skale-admin:
     <<: *skale_base
     container_name: skale_admin
-    image: skalenetwork/admin:2.10.0
+    image: skalenetwork/admin:2.10.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   skale-api:
     <<: *skale_base
     container_name: skale_api
-    image: skalenetwork/admin:2.10.0
+    image: skalenetwork/admin:2.10.1
     network_mode: host
     tty: true
     cap_add:
@@ -105,7 +105,7 @@ services:
   celery:
     <<: *skale_base
     container_name: celery
-    image: skalenetwork/admin:2.10.0
+    image: skalenetwork/admin:2.10.1
     network_mode: host
     tty: true
     environment:

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -81,7 +81,7 @@ envs:
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
       constantGasPrice: 10000000000
-      disableSelfDestructPatchTimestamp: 1762773498
+      disableSelfDestructPatchTimestamp: 1764158400
 
     skaled_cmd: ["-v 2", "--aa no"]
 

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -29,6 +29,7 @@ envs:
       snapshotDownloadInactiveTimeout: 120
       dbStorageLimit: 70000000000
       maxConsensusStorageBytes: 70000000000
+      disableSelfDestructPatchTimestamp: 1762773498
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -80,6 +81,7 @@ envs:
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
       constantGasPrice: 10000000000
+      disableSelfDestructPatchTimestamp: 1762773498
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -130,6 +132,7 @@ envs:
       snapshotDownloadInactiveTimeout: 120
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
+      disableSelfDestructPatchTimestamp: 1762273498
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -180,6 +183,7 @@ envs:
       snapshotDownloadInactiveTimeout: 120
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
+      disableSelfDestructPatchTimestamp: 1
 
     skaled_cmd:
       ["-v 3", "--web3-trace", "--enable-debug-behavior-apis", "--aa no"]

--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -132,7 +132,7 @@ envs:
       snapshotDownloadInactiveTimeout: 120
       dbStorageLimit: 30000000000
       maxConsensusStorageBytes: 30000000000
-      disableSelfDestructPatchTimestamp: 1762273498
+      disableSelfDestructPatchTimestamp: 1762357543
 
     skaled_cmd: ["-v 2", "--aa no"]
 

--- a/redis.conf
+++ b/redis.conf
@@ -12,7 +12,7 @@ save 900 1
 save 300 10
 save 60 10000
 dbfilename dump.rdb
-dir /data
+dir /data/db
 
 appendonly yes
 appendfilename "appendonly.aof"

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -181,8 +181,8 @@ envs:
       flexibleDeploymentPatchTimestamp: 1721826000
       verifyBlsSyncPatchTimestamp: 1721829600
       externalGasPatchTimestamp: 1727712000
-      invalidTransactionFormatPatchTimestamp: 0
-      clearPartialReceiptsPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 1745319600
+      clearPartialReceiptsPatchTimestamp: 1745323200
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -78,7 +78,7 @@ envs:
         parallel-stormy-spica: 1723460400
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1728817200
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
@@ -90,8 +90,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -182,7 +181,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 1721826000
       verifyBlsSyncPatchTimestamp: 1721829600
       externalGasPatchTimestamp: 1727712000
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
@@ -194,8 +193,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -286,7 +284,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 0
       externalGasPatchTimestamp: 1727712000
-      maxFeePerGasPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
@@ -298,8 +296,7 @@ envs:
         before: 1800
         after: 900
 
-    schain_cmd:
-      ["-v 2", "--aa no"]
+    schain_cmd: ["-v 2", "--aa no"]
 
     node:
       common:
@@ -392,7 +389,7 @@ envs:
       flexibleDeploymentPatchTimestamp: 0
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1727353446
-      maxFeePerGasPatchTimestamp: 1741956440
+      invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -78,8 +78,8 @@ envs:
         parallel-stormy-spica: 1723460400
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1728817200
-      invalidTransactionFormatPatchTimestamp: 0
-      clearPartialReceiptsPatchTimestamp: 0
+      invalidTransactionFormatPatchTimestamp: 1746442800
+      clearPartialReceiptsPatchTimestamp: 1746615600
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000


### PR DESCRIPTION
This pull request updates configuration files to support new features and improve reliability for the SKALE node and its supporting services. The main changes include upgrading the `skaled` container version, updating Redis data directory paths, and introducing a new parameter to control the timing of the self-destruct patch in multiple environments.

**Container and Service Updates**
* Upgraded the `skaled` container image version in `containers.json` from `4.1.0-develop.56-fair` to `4.1.0-develop.63-fair`, which likely includes new features and bug fixes.
* Updated the Redis data directory mount path in `docker-compose-fair.yml` from `/data` to `/data/db`, ensuring consistency with the new configuration and potentially improving data organization.
* Changed the Redis `dir` setting in `redis.conf` from `/data` to `/data/db` to match the updated mount path.

**Environment Configuration**
* Added the `disableSelfDestructPatchTimestamp` parameter to several environments in `fair_static_params.yaml`, allowing fine-grained control over when the self-destruct patch is applied for each environment. [[1]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R32) [[2]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R84) [[3]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R135) [[4]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R186)