### PR TITLE
Update skaled and admin versions - develop

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.63-fair",
+    "version": "4.1.0-develop.63",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -116,7 +116,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     network_mode: host
     tty: true
     cap_add:
@@ -152,7 +152,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose-passive.yml
+++ b/docker-compose-passive.yml
@@ -13,7 +13,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     network_mode: host
     tty: true
     cap_add:
@@ -107,7 +107,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-fair.7
+    image: skalenetwork/admin:3.2.0-develop.1
     network_mode: host
     tty: true
     environment:


### PR DESCRIPTION
This pull request updates the container image versions for several services to use the latest `develop` branch builds instead of the previous `fair` builds. The main goal is to ensure all relevant services are running the most recent development images, which may include new features, bug fixes, or compatibility updates.

**Container image updates:**

* Updated the `skalenetwork/schain` container in `containers.json` to use version `4.1.0-develop.63` instead of `4.1.0-develop.63-fair`.

**Docker Compose service image updates:**

* Changed the `skalenetwork/admin` image from `3.2.0-fair.7` to `3.2.0-develop.1` for the following services in `docker-compose-fair.yml`: `boot-admin`, `admin`, `boot-api`, and `api`. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L119-R119) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L155-R155)
* Updated the `skalenetwork/admin` image to `3.2.0-develop.1` for the `admin` service in `docker-compose-passive.yml`.
* Updated the `skalenetwork/admin` image for the `admin`, `api`, and `celery` services in `docker-compose.yml` to use `3.2.0-develop.1` instead of the previous `fair` build. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R29) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L74-R74) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L110-R110)