### PR TITLE
Update filebeat version to 9.1.5 for base testnet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,7 @@ services:
     <<: *skale_base
     container_name: skale_filebeat
     user: root
-    image: docker.elastic.co/beats/filebeat:7.3.1
+    image: elastic/filebeat:9.1.5
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -1,26 +1,29 @@
 filebeat.inputs:
-- type: container
-  paths:
-    - '/var/lib/docker/containers/*/*.log'
+  - type: filestream
+    id: docker-containers
+    paths:
+      - /var/lib/docker/containers/*/*.log
+    parsers:
+      - container:
+          stream: all
 
-- type: log
-  enabled: true
-  paths:
-    - '/var/log/docker-lvmpy/lvmpy.log'
+  - type: filestream
+    id: lvmpy-log
+    enabled: true
+    paths:
+      - /var/log/docker-lvmpy/lvmpy.log
 
 processors:
-- add_host_metadata:
-#    netinfo.enabled: false
-- add_docker_metadata:
-    host: "unix:///var/run/skale/docker.sock"
-- decode_json_fields:
-    fields: ["message", "log"]
-#    target: "json"
-    target: ""
-    overwrite_keys: true
+  - add_host_metadata: {}
+  - add_docker_metadata:
+      host: "unix:///var/run/skale/docker.sock"
+  - decode_json_fields:
+      fields: ["message"]
+      target: ""
+      overwrite_keys: true
 
 output.logstash:
-  hosts: ${FILEBEAT_HOST}
+  hosts: ["${FILEBEAT_HOST}"]
+  ssl.enabled: true
 
-logging.json: true
 logging.metrics.enabled: false

--- a/filebeat.yml.j2
+++ b/filebeat.yml.j2
@@ -1,31 +1,34 @@
 filebeat.inputs:
-- type: container
-  paths:
-    - '/var/lib/docker/containers/*/*.log'
+  - type: filestream
+    id: docker-containers
+    paths:
+      - /var/lib/docker/containers/*/*.log
+    parsers:
+      - container:
+          stream: all
 
-- type: log
-  enabled: true
-  paths:
-    - '/var/log/docker-lvmpy/lvmpy.log'
+  - type: filestream
+    id: lvmpy-log
+    enabled: true
+    paths:
+      - /var/log/docker-lvmpy/lvmpy.log
 
 processors:
-- add_host_metadata:
-#    netinfo.enabled: false
-- add_docker_metadata:
-    host: "unix:///var/run/skale/docker.sock"
-- add_fields:
-    fields:
-      id: {{ id }}
-      ip: '{{ ip }}'
-      contract_address: '{{ contract_address }}'
-- decode_json_fields:
-    fields: ["message", "log"]
-#    target: "json"
-    target: ""
-    overwrite_keys: true
+  - add_host_metadata: {}
+  - add_docker_metadata:
+      host: "unix:///var/run/skale/docker.sock"
+  - add_fields:
+      fields:
+        id: {{ id }}
+        ip: '{{ ip }}'
+        contract_address: '{{ contract_address }}'
+  - decode_json_fields:
+      fields: ["message"]
+      target: ""
+      overwrite_keys: true
 
 output.logstash:
-  hosts: ${FILEBEAT_HOST}
+  hosts: ["${FILEBEAT_HOST}"]
+  ssl.enabled: true
 
-logging.json: true
 logging.metrics.enabled: false


### PR DESCRIPTION
This pull request updates the Filebeat configuration and Docker Compose setup to use a newer Filebeat version and modernizes log collection by switching to the `filestream` input. It also improves security and compatibility with Logstash by enabling SSL and updating output formatting.

**Filebeat configuration modernization:**

* Changed Filebeat input type from `container` and `log` to `filestream` in both `filebeat.yml` and `filebeat.yml.j2`, and added container log parsing for better Docker log support. [[1]](diffhunk://#diff-ac549ee29f3b6218b119be5abfd37d57a6e6bacbc746e6395990c28ee0b2d955L2-L25) [[2]](diffhunk://#diff-286d6dbfdc37a9edbfc1d88b367af3beff353351e420ae09cfcbc79c783f1a83L2-R17)
* Updated the processor configuration to use the correct fields and improved metadata handling for Docker and host information. [[1]](diffhunk://#diff-ac549ee29f3b6218b119be5abfd37d57a6e6bacbc746e6395990c28ee0b2d955L2-L25) [[2]](diffhunk://#diff-286d6dbfdc37a9edbfc1d88b367af3beff353351e420ae09cfcbc79c783f1a83L22-L30)

**Security and compatibility improvements:**

* Enabled SSL for Logstash output and changed host configuration to use array syntax for improved compatibility. [[1]](diffhunk://#diff-ac549ee29f3b6218b119be5abfd37d57a6e6bacbc746e6395990c28ee0b2d955L2-L25) [[2]](diffhunk://#diff-286d6dbfdc37a9edbfc1d88b367af3beff353351e420ae09cfcbc79c783f1a83L22-L30)

**Dependency updates:**

* Upgraded Filebeat Docker image from version `7.3.1` to `9.1.5` in `docker-compose.yml` for enhanced features and security.