### PR TITLE
2243 Add eth_getLogs response limit

### DIFF
--- a/fair_static_params.yaml
+++ b/fair_static_params.yaml
@@ -47,6 +47,7 @@ envs:
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 1000
+      getResponseLogCountLimit: 10000
 
     info:
       chain_id: "0x3A6"
@@ -99,6 +100,7 @@ envs:
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 4000
+      getResponseLogCountLimit: 10000
 
     info:
       chain_id: "0x3A7"
@@ -150,6 +152,7 @@ envs:
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 1000
+      getResponseLogCountLimit: 10000
 
     info:
       chain_id: "0x3A9"
@@ -202,6 +205,7 @@ envs:
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 1000
+      getResponseLogCountLimit: 10000
 
     info:
       chain_id: "0x3A8"

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,6 +99,7 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        getResponseLogCountLimit: 10000
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -202,6 +203,7 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        getResponseLogCountLimit: 10000
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -305,6 +307,7 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        getResponseLogCountLimit: 10000
       admin:
         automatic_repair: false
       small:
@@ -411,6 +414,7 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        getResponseLogCountLimit: 10000
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000


### PR DESCRIPTION
This pull request introduces a new configuration parameter, `getResponseLogCountLimit`, set to 10,000 in multiple environments within both the `fair_static_params.yaml` and `static_params.yaml` files. The addition aims to standardize a limit on response log counts across several chains and environment profiles.

New configuration parameter added:

**`fair_static_params.yaml` updates:**
* Added `getResponseLogCountLimit: 10000` to the environment settings for chains with IDs `0x3A6`, `0x3A7`, `0x3A9`, and `0x3A8`, ensuring consistent log count limits across these chains. [[1]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R50) [[2]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R103) [[3]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R155) [[4]](diffhunk://#diff-27c451db02b05eef13e2851dca3a3945ff8b05c0e9791ed5a8eab0225c9870f5R208)

**`static_params.yaml` updates:**
* Added `getResponseLogCountLimit: 10000` to multiple environment profiles (`default`, `small`, `admin`) to enforce the same log count limit in these configurations. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR102) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR206) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR310) [[4]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR417)