### PR TITLE
Update redis container, fix static params

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.63",
+    "version": "4.1.0-develop.72",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -188,7 +188,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:8.2.2-alpine"
+    image: "redis:8.4.0-alpine"
     network_mode: host
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:8.2.2-alpine"
+    image: "redis:8.4.0-alpine"
     network_mode: host
     tty: true
     environment:

--- a/fair_base_config.json
+++ b/fair_base_config.json
@@ -21,7 +21,7 @@
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
 		"skaleDisableChainIdCheck": true,
-		"getResponseLogCountLimit": 2000,
+		"getResponseLogCountLimit": 10000,
 		"allowPreEIP155Txns": true
 	},
 	"unddos": {

--- a/schain_base_config.json
+++ b/schain_base_config.json
@@ -22,7 +22,7 @@
 		"blockReward": "0x4563918244F40000",
 		"externalGasDifficulty": "0x01",
 		"skaleDisableChainIdCheck": true,
-		"getResponseLogCountLimit": 2000
+		"getResponseLogCountLimit": 10000
 	},
 	"unddos": {
 		"origins": [

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,7 +99,6 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
-        getResponseLogCountLimit: 10000
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -203,7 +202,6 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
-        getResponseLogCountLimit: 10000
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -307,7 +305,6 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
-        getResponseLogCountLimit: 10000
       admin:
         automatic_repair: false
       small:
@@ -414,7 +411,6 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
-        getResponseLogCountLimit: 10000
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000


### PR DESCRIPTION
This pull request includes several dependency updates and a configuration cleanup. The main changes are upgrading the `redis` container version across multiple environments, updating the `skalenetwork/schain` container version, and removing the unused `getResponseLogCountLimit` parameter from the static configuration.

Dependency updates:

* Upgraded the `redis` container image from version `8.2.2-alpine` to `8.4.0-alpine` in both `docker-compose.yml` and `docker-compose-fair.yml` to ensure the latest features and security patches. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L125-R125) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L191-R191)
* Updated the `skalenetwork/schain` container version from `4.1.0-develop.63` to `4.1.0-develop.72` in `containers.json`.

Configuration cleanup:

* Removed the unused `getResponseLogCountLimit` parameter from multiple environment sections in `static_params.yaml` to simplify configuration and avoid confusion. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL102) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL206) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL310) [[4]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL417)