### PR TITLE
Update admin and skaled versions - beta

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.0.2",
+    "version": "4.0.3-beta.0",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -16,7 +16,7 @@ services:
   skale-sync-admin:
     <<: *skale_base
     container_name: skale_sync_admin
-    image: skalenetwork/admin:2.10.3
+    image: skalenetwork/admin:2.6.3-beta.0
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   skale-admin:
     <<: *skale_base
     container_name: skale_admin
-    image: skalenetwork/admin:2.10.3
+    image: skalenetwork/admin:2.6.3-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   skale-api:
     <<: *skale_base
     container_name: skale_api
-    image: skalenetwork/admin:2.10.3
+    image: skalenetwork/admin:2.6.3-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -105,7 +105,7 @@ services:
   celery:
     <<: *skale_base
     container_name: celery
-    image: skalenetwork/admin:2.10.3
+    image: skalenetwork/admin:2.6.3-beta.0
     network_mode: host
     tty: true
     environment:


### PR DESCRIPTION
This pull request updates the version of the `skalenetwork/schain` container and downgrades the `skalenetwork/admin` image to a beta version across multiple services in both `docker-compose.yml` and `docker-compose-sync.yml`. These changes likely aim to test or align with a specific beta release of the admin image and the latest beta of the schain container.

**Container version updates:**

* Updated `skalenetwork/schain` container version from `4.0.2` to `4.0.3-beta.0` in `containers.json`.

**Admin image downgrades to beta:**

* Changed `skalenetwork/admin` image from `2.10.3` to `2.6.3-beta.0` for the following services in `docker-compose.yml`:
  - `skale-admin`
  - `skale-api`
  - `celery`
* Changed `skalenetwork/admin` image from `2.10.3` to `2.6.3-beta.0` for the `skale-sync-admin` service in `docker-compose-sync.yml`.