### PR TITLE
Add BITE variable to admin service and update admin and skaled versions 

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.73",
+    "version": "1247",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "1247",
+    "version": "4.1.0-develop.73",
     "custom_args": {
       "ulimits_list": [
         {

--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.72",
+    "version": "4.1.0-develop.73",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -29,7 +29,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.2.0-develop.1
+    image: skalenetwork/admin:3.3.0-develop.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -72,7 +72,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-develop.1
+    image: skalenetwork/admin:3.3.0-develop.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -116,7 +116,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.2.0-develop.1
+    image: skalenetwork/admin:3.3.0-develop.1
     network_mode: host
     tty: true
     cap_add:
@@ -152,7 +152,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-develop.1
+    image: skalenetwork/admin:3.3.0-develop.1
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-develop.1
+    image: skalenetwork/admin:3.2.0-develop.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -79,7 +79,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-develop.1
+    image: skalenetwork/admin:3.2.0-develop.2
     network_mode: host
     tty: true
     cap_add:
@@ -165,7 +165,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-stable.0
+    image: skalenetwork/watchdog:3.1.0-develop.1
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.2.0-develop.2
+    image: skalenetwork/admin:3.3.0-develop.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -56,6 +56,7 @@ services:
       DISABLE_COLORS: "True"
       PASSIVE_NODE: ${PASSIVE_NODE}
       SCHAIN_NAME: ${SCHAIN_NAME}
+      BITE: ${BITE}
 
     command: >
       sh -c 'if [ "$$PASSIVE_NODE" = "True" ]; then
@@ -79,7 +80,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.2.0-develop.2
+    image: skalenetwork/admin:3.3.0-develop.1
     network_mode: host
     tty: true
     cap_add:
@@ -118,7 +119,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.2.0-develop.1
+    image: skalenetwork/admin:3.3.0-develop.1
     network_mode: host
     tty: true
     environment:


### PR DESCRIPTION
This pull request primarily updates the container and image versions used in the deployment configuration files, ensuring the environment uses the latest development builds. Additionally, it introduces a new environment variable and updates the watchdog service to a development version. These changes help keep the stack current and potentially introduce new features or fixes from upstream.

**Container and image version updates:**

* Updated the `skalenetwork/schain` container version from `4.1.0-develop.72` to `4.1.0-develop.73` in `containers.json`.
* Updated all `skalenetwork/admin` service images from `3.2.0-develop.1` to `3.3.0-develop.1` in both `docker-compose.yml` and `docker-compose-fair.yml` for the `admin`, `api`, `celery`, `boot-admin`, and `boot-api` services. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L32-R32) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L75-R75) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L119-R119) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L155-R155) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L29-R29) [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L82-R83) [[7]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L121-R122)

**Configuration/environment changes:**

* Added a new environment variable `BITE` to the `admin` service in `docker-compose.yml`, allowing for additional configuration via environment.

**Watchdog service update:**

* Changed the `skalenetwork/watchdog` image from `3.1.0-stable.0` to `3.1.0-develop.1` in `docker-compose.yml`, switching the watchdog to a development build.