### PR TITLE
update skaled version to 4.1.0-develop.82-bite

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.63-bite-relwithdebinfo",
+    "version": "4.1.0-develop.82-bite",
     "custom_args": {
       "ulimits_list": [
         {


### PR DESCRIPTION
This pull request updates the version of the `skalenetwork/schain` container in the `containers.json` file. The change is minor and consists only of bumping the container version to a newer build. 

- Updated the `skalenetwork/schain` container version from `4.1.0-develop.63-bite-relwithdebinfo` to `4.1.0-develop.82-bite` in `containers.json`.