### PR TITLE
update component versions - 5.0 release, add timestamps

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.73",
+    "version": "5.0.0-beta.0",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.1.0
+    image: skalenetwork/transaction-manager:3.2.0-beta.0
     network_mode: host
     tty: true
     volumes:
@@ -23,7 +23,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.3.0-develop.1
+    image: skalenetwork/admin:3.3.0-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -47,7 +47,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-develop.1
+    image: skalenetwork/admin:3.3.0-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.3.0-develop.1
+    image: skalenetwork/admin:3.3.0-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -88,7 +88,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-develop.1
+    image: skalenetwork/admin:3.3.0-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -105,7 +105,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:8.4.0-alpine"
+    image: "redis:8.6.0-alpine"
     network_mode: host
     tty: true
     environment:
@@ -120,7 +120,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-stable.0
+    image: skalenetwork/watchdog:3.1.0-develop.1
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300
@@ -132,7 +132,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.29.4
+    image: nginx:1.29.5
     container_name: sk_nginx
     network_mode: host
     depends_on:
@@ -179,7 +179,7 @@ services:
     <<: *sk_base
     container_name: sk_filebeat
     user: root
-    image: elastic/filebeat:9.1.5
+    image: elastic/filebeat:9.2.5
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.1.0
+    image: skalenetwork/transaction-manager:3.2.0-beta.0
     network_mode: host
     tty: true
     volumes:
@@ -22,7 +22,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-develop.1
+    image: skalenetwork/admin:3.3.0-beta.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -50,7 +50,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-develop.1
+    image: skalenetwork/admin:3.3.0-beta.0
     network_mode: host
     tty: true
     cap_add:
@@ -66,7 +66,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.3.0-develop.1
+    image: skalenetwork/admin:3.3.0-beta.0
     network_mode: host
     tty: true
     command: "celery -A tools.notifications.tasks worker --loglevel=info"
@@ -77,7 +77,7 @@ services:
   redis:
     <<: *sk_base
     container_name: sk_redis
-    image: "redis:8.4.0-alpine"
+    image: "redis:8.6.0-alpine"
     network_mode: host
     tty: true
     environment:
@@ -110,7 +110,7 @@ services:
 
   nginx:
     <<: *sk_base
-    image: nginx:1.29.4
+    image: nginx:1.29.5
     container_name: sk_nginx
     network_mode: host
     depends_on:
@@ -158,7 +158,7 @@ services:
     <<: *sk_base
     container_name: sk_filebeat
     user: root
-    image: elastic/filebeat:9.1.5
+    image: elastic/filebeat:9.2.5
     network_mode: host
     environment:
       FILEBEAT_HOST: ${FILEBEAT_HOST}

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -76,6 +76,9 @@ envs:
         elated-tan-skat: 1723460400
         green-giddy-denebola: 1723460400
         parallel-stormy-spica: 1723460400
+        affectionate-immediate-pollux: 0
+        light-vast-diphda: 0
+        fussy-smoggy-megrez: 0
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1728817200
       invalidTransactionFormatPatchTimestamp: 1746442800
@@ -84,7 +87,9 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-
+      groupIndexInitPatchTimestamp: 0
+      currentBlockRandomPatchTimestamp: 0
+      singleStateCommitPerBlockPatchTimestamp: 0
     ima:
       time_frame:
         before: 1800
@@ -187,6 +192,9 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
+      groupIndexInitPatchTimestamp: 0
+      currentBlockRandomPatchTimestamp: 0
+      singleStateCommitPerBlockPatchTimestamp: 0
 
     ima:
       time_frame:
@@ -290,6 +298,9 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
+      groupIndexInitPatchTimestamp: 0
+      currentBlockRandomPatchTimestamp: 0
+      singleStateCommitPerBlockPatchTimestamp: 0
 
     ima:
       time_frame:
@@ -395,6 +406,9 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
+      groupIndexInitPatchTimestamp: 0
+      currentBlockRandomPatchTimestamp: 0
+      singleStateCommitPerBlockPatchTimestamp: 0
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -79,6 +79,16 @@ envs:
         affectionate-immediate-pollux: 0
         light-vast-diphda: 0
         fussy-smoggy-megrez: 0
+        round-hasty-alsafi: 0
+        brave-triangulum-australe: 0
+        gargantuan-wealthy-zosma: 0
+        portly-passionate-sirius: 0
+        haunting-devoted-deneb: 0
+        curly-red-alterf: 0
+        frayed-decent-antares: 0
+        wan-red-ain: 0
+        adorable-quaint-bellatrix: 0
+        wary-teeming-mizar: 0
       verifyBlsSyncPatchTimestamp: 1722855600
       externalGasPatchTimestamp: 1728817200
       invalidTransactionFormatPatchTimestamp: 1746442800

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -80,7 +80,6 @@ envs:
         light-vast-diphda: 0
         fussy-smoggy-megrez: 0
         round-hasty-alsafi: 0
-        brave-triangulum-australe: 0
         gargantuan-wealthy-zosma: 0
         portly-passionate-sirius: 0
         haunting-devoted-deneb: 0


### PR DESCRIPTION
This pull request updates several container images and configuration parameters across multiple files to introduce new versions and enable new features. The main changes are version bumps for core services and the addition of new patch timestamps in the configuration, which likely enable new protocol features or behaviors.

Container image updates:

* Upgraded `skaled` container in `containers.json` to version `5.0.0-beta.0`, moving from the previous develop version.
* Updated `skalenetwork/transaction-manager` and `skalenetwork/admin` images to their latest beta versions in both `docker-compose.yml` and `docker-compose-fair.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-R16) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L25-R25) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L16-R16) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L26-R26) [[5]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L50-R50) [[6]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L74-R74) [[7]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L91-R91) [[8]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L53-R53) [[9]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L69-R69)
* Updated supporting service images: `redis` to `8.6.0-alpine`, `nginx` to `1.29.5`, and `elastic/filebeat` to `9.2.5` in both compose files. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L80-R80) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L113-R113) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L161-R161) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L108-R108) [[5]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L135-R135) [[6]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L182-R182)
* Changed `skalenetwork/watchdog` image to a develop version in `docker-compose-fair.yml`.

Configuration parameter additions:

* Added new patch timestamps (`groupIndexInitPatchTimestamp`, `currentBlockRandomPatchTimestamp`, `singleStateCommitPerBlockPatchTimestamp`) set to `0` in multiple environments in `static_params.yaml`, likely to activate new protocol features immediately. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL87-R92) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR195-R197) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR301-R303) [[4]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR409-R411)
* Introduced three new environments with timestamps set to `0` in `static_params.yaml`.