### PR TITLE
update bounty agent to 3.1.0-beta.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
   bounty:
     <<: *sk_base
     container_name: sk_bounty
-    image: skalenetwork/bounty-agent:2.2.0-stable.0
+    image: skalenetwork/bounty-agent:3.1.0-beta.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}:/skale_vol


### PR DESCRIPTION
This pull request updates the `bounty` service in the `docker-compose.yml` file to use a newer, beta version of its Docker image. This will allow the service to take advantage of new features or fixes introduced in `3.1.0-beta.0`. 

- Updated the `bounty` service Docker image from `skalenetwork/bounty-agent:2.2.0-stable.0` to `skalenetwork/bounty-agent:3.1.0-beta.0` in `docker-compose.yml`.