### PR TITLE
Develop to beta - bounty update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
   bounty:
     <<: *sk_base
     container_name: sk_bounty
-    image: skalenetwork/bounty-agent:2.2.0-stable.0
+    image: skalenetwork/bounty-agent:3.1.0-beta.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}:/skale_vol


### PR DESCRIPTION
This pull request updates the `bounty` service in the `docker-compose.yml` file to use a newer, beta version of the `skalenetwork/bounty-agent` image. This change will allow the service to leverage the latest features and fixes available in version `3.1.0-beta.0`.