### PR TITLE
update watchdog volumes and version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,10 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-develop.1
+    image: skalenetwork/watchdog:3.2.0-beta.0
     network_mode: host
+    volumes:
+      - ${SKALE_DIR}/node_data/settings:/settings:ro
     environment:
       ALLOWED_TS_DIFF: 300
       FLASK_APP_PORT: 3010


### PR DESCRIPTION
This pull request updates the configuration for the `watchdog` service in `docker-compose.yml`, primarily to upgrade the service and improve its access to settings.

Watchdog service update:

* Upgraded the `watchdog` container image from `skalenetwork/watchdog:3.1.0-develop.1` to `skalenetwork/watchdog:3.2.0-beta.0`, bringing in new features and improvements.
* Added a read-only volume mount for `${SKALE_DIR}/node_data/settings` to `/settings`, allowing the service to access settings from the host machine.