### PR TITLE
update admin version - cleaner fix

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -23,7 +23,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.3.0-beta.1
+    image: skalenetwork/admin:3.3.0-beta.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -47,7 +47,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-beta.1
+    image: skalenetwork/admin:3.3.0-beta.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.3.0-beta.1
+    image: skalenetwork/admin:3.3.0-beta.2
     network_mode: host
     tty: true
     cap_add:
@@ -88,7 +88,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-beta.1
+    image: skalenetwork/admin:3.3.0-beta.2
     network_mode: host
     tty: true
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-beta.1
+    image: skalenetwork/admin:3.3.0-beta.2
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -46,7 +46,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-beta.1
+    image: skalenetwork/admin:3.3.0-beta.2
     network_mode: host
     tty: true
     cap_add:
@@ -62,7 +62,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.3.0-beta.1
+    image: skalenetwork/admin:3.3.0-beta.2
     network_mode: host
     tty: true
     command: "celery -A tools.notifications.tasks worker --loglevel=info"


### PR DESCRIPTION
This pull request updates the container images for several services in both `docker-compose-fair.yml` and `docker-compose.yml` files. The main change is upgrading the `skalenetwork/admin` image from version `3.3.0-beta.1` to `3.3.0-beta.2` across all relevant services.

Container image version upgrades:

* [`docker-compose-fair.yml`](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L26-R26): Updated the `skalenetwork/admin` image to `3.3.0-beta.2` for `boot-admin`, `admin`, `boot-api`, and `api` services. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L26-R26) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L50-R50) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L74-R74) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L91-R91)
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L26-R26): Updated the `skalenetwork/admin` image to `3.3.0-beta.2` for `admin`, `api`, and `celery` services. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L26-R26) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L49-R49) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L65-R65)