### PR TITLE
Update versions for bite-2

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.86-bite",
+    "version": "5.1.0-develop.36-bite",
     "custom_args": {
       "ulimits_list": [
         {

--- a/schain_base_config.json
+++ b/schain_base_config.json
@@ -20,7 +20,7 @@
 		"difficultyBoundDivisor": "0x0800",
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
-		"externalGasDifficulty": "0x00",
+		"externalGasDifficulty": "0x01",
 		"skaleDisableChainIdCheck": true,
                 "getLogsBlocksLimit": 2000
 	},

--- a/schain_base_config.json
+++ b/schain_base_config.json
@@ -20,7 +20,7 @@
 		"difficultyBoundDivisor": "0x0800",
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
-		"externalGasDifficulty": "0x01",
+		"externalGasDifficulty": "0x00",
 		"skaleDisableChainIdCheck": true,
                 "getLogsBlocksLimit": 2000
 	},

--- a/schain_precompiled_contracts.json
+++ b/schain_precompiled_contracts.json
@@ -228,5 +228,35 @@
       },
       "startingBlock": "0x0"
     }
+  },
+  "0x000000000000000000000000000000000000001B": {
+    "precompiled": {
+      "name": "submitCTX",
+      "linear": {
+        "base": 15,
+        "word": 0
+      },
+      "startingBlock": "0x0"
+    }
+  },
+  "0x000000000000000000000000000000000000001C": {
+    "precompiled": {
+      "name": "encryptECIES",
+      "linear": {
+        "base": 15,
+        "word": 0
+      },
+      "startingBlock": "0x0"
+    }
+  },
+  "0x000000000000000000000000000000000000001D": {
+    "precompiled": {
+      "name": "encryptTE",
+      "linear": {
+        "base": 15,
+        "word": 0
+      },
+      "startingBlock": "0x0"
+    }
   }
 }

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -103,6 +103,9 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        dynamicPricingMinPrice: 47619047620
+        dynamicPricingMaxPrice: 1000000000000000000
+        dynamicPricingStartPrice: 47619047620
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -187,10 +190,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
-      currentBlockRandomPatchTimestamp: 1775473200
-      singleStateCommitPerBlockPatchTimestamp: 1775476800
-      bite2PatchTimestamp: 1775480400
-      contractCreationReadOnlyPatchTimestamp: 1775484000
+      currentBlockRandomPatchTimestamp: 1775136600
+      singleStateCommitPerBlockPatchTimestamp: 1775136600
+      bite2PatchTimestamp: 1775136600
+      contractCreationReadOnlyPatchTimestamp: 1775136600
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -210,6 +213,8 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        admin:
+          automatic_repair: false
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -287,17 +292,17 @@ envs:
       pushZeroPatchTimestamp: 1712142000
       precompiledConfigPatchTimestamp: 1712314800
       correctForkInPowPatchTimestamp: 1711969200
-      EIP1559TransactionsPatchTimestamp: 0
-      fastConsensusPatchTimestamp: 0
-      flexibleDeploymentPatchTimestamp: 0
-      verifyBlsSyncPatchTimestamp: 0
+      EIP1559TransactionsPatchTimestamp: 1711969200
+      fastConsensusPatchTimestamp: 1711969200
+      flexibleDeploymentPatchTimestamp: 1711969200
+      verifyBlsSyncPatchTimestamp: 1711969200
       externalGasPatchTimestamp: 1727712000
-      invalidTransactionFormatPatchTimestamp: 0
-      clearPartialReceiptsPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 1775473200
-      singleStateCommitPerBlockPatchTimestamp: 1775476800
-      bite2PatchTimestamp: 1775480400
-      contractCreationReadOnlyPatchTimestamp: 1775484000
+      invalidTransactionFormatPatchTimestamp: 1711969200
+      clearPartialReceiptsPatchTimestamp: 1711969200
+      currentBlockRandomPatchTimestamp: 1775136600
+      singleStateCommitPerBlockPatchTimestamp: 1775136600
+      bite2PatchTimestamp: 1775136600
+      contractCreationReadOnlyPatchTimestamp: 1775136600
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -317,6 +322,9 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        dynamicPricingMinPrice: 47619047620
+        dynamicPricingMaxPrice: 1000000000000000000
+        dynamicPricingStartPrice: 47619047620
       admin:
         automatic_repair: false
       small:
@@ -403,10 +411,10 @@ envs:
       externalGasPatchTimestamp: 1727353446
       invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
-      currentBlockRandomPatchTimestamp: 1775473200
-      singleStateCommitPerBlockPatchTimestamp: 1775476800
-      bite2PatchTimestamp: 1775480400
-      contractCreationReadOnlyPatchTimestamp: 1775484000
+      currentBlockRandomPatchTimestamp: 1775136600
+      singleStateCommitPerBlockPatchTimestamp: 1775136600
+      bite2PatchTimestamp: 1775136600
+      contractCreationReadOnlyPatchTimestamp: 1775136600
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -427,6 +435,9 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
+        dynamicPricingMinPrice: 47619047620
+        dynamicPricingMaxPrice: 1000000000000000000
+        dynamicPricingStartPrice: 47619047620
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -189,10 +189,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
-      currentBlockRandomPatchTimestamp: 1775156601
-      singleStateCommitPerBlockPatchTimestamp: 1775156601
-      bite2PatchTimestamp: 1775156601
-      contractCreationReadOnlyPatchTimestamp: 1775156601
+      currentBlockRandomPatchTimestamp: 1775158001
+      singleStateCommitPerBlockPatchTimestamp: 1775158001
+      bite2PatchTimestamp: 1775158001
+      contractCreationReadOnlyPatchTimestamp: 1775158001
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -106,6 +106,8 @@ envs:
         dynamicPricingMinPrice: 47619047620
         dynamicPricingMaxPrice: 1000000000000000000
         dynamicPricingStartPrice: 47619047620
+        admin:
+          automatic_repair: false
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -190,10 +192,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
-      currentBlockRandomPatchTimestamp: 1775153001
-      singleStateCommitPerBlockPatchTimestamp: 1775153001
-      bite2PatchTimestamp: 1775153001
-      contractCreationReadOnlyPatchTimestamp: 1775153001
+      currentBlockRandomPatchTimestamp: 1775156601
+      singleStateCommitPerBlockPatchTimestamp: 1775156601
+      bite2PatchTimestamp: 1775156601
+      contractCreationReadOnlyPatchTimestamp: 1775156601
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -190,10 +190,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
-      currentBlockRandomPatchTimestamp: 1775136600
-      singleStateCommitPerBlockPatchTimestamp: 1775136600
-      bite2PatchTimestamp: 1775136600
-      contractCreationReadOnlyPatchTimestamp: 1775136600
+      currentBlockRandomPatchTimestamp: 1775153001
+      singleStateCommitPerBlockPatchTimestamp: 1775153001
+      bite2PatchTimestamp: 1775153001
+      contractCreationReadOnlyPatchTimestamp: 1775153001
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -103,9 +103,6 @@ envs:
         logLevelConfig: "info"
         pg-threads: 10
         pg-threads-limit: 10
-        dynamicPricingMinPrice: 47619047620
-        dynamicPricingMaxPrice: 1000000000000000000
-        dynamicPricingStartPrice: 47619047620
         admin:
           automatic_repair: false
       small:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -80,6 +80,10 @@ envs:
       externalGasPatchTimestamp: 1728817200
       invalidTransactionFormatPatchTimestamp: 1746442800
       clearPartialReceiptsPatchTimestamp: 1746615600
+      currentBlockRandomPatchTimestamp: 0
+      singleStateCommitPerBlockPatchTimestamp: 0
+      bite2PatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 0
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -183,6 +187,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
+      currentBlockRandomPatchTimestamp: 1775473200
+      singleStateCommitPerBlockPatchTimestamp: 1775476800
+      bite2PatchTimestamp: 1775480400
+      contractCreationReadOnlyPatchTimestamp: 1775484000
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -286,6 +294,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
+      currentBlockRandomPatchTimestamp: 1775473200
+      singleStateCommitPerBlockPatchTimestamp: 1775476800
+      bite2PatchTimestamp: 1775480400
+      contractCreationReadOnlyPatchTimestamp: 1775484000
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -391,6 +403,10 @@ envs:
       externalGasPatchTimestamp: 1727353446
       invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
+      currentBlockRandomPatchTimestamp: 1775473200
+      singleStateCommitPerBlockPatchTimestamp: 1775476800
+      bite2PatchTimestamp: 1775480400
+      contractCreationReadOnlyPatchTimestamp: 1775484000
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000


### PR DESCRIPTION
This pull request updates the SKALE chain configuration to support several new protocol patches and upgrades the `schain` container version. The main changes include introducing new patch activation timestamps across multiple environments, updating the `schain` container version, and adjusting a consensus parameter.

**Protocol patch activation (across multiple environments):**
- Added new patch activation timestamps for `currentBlockRandom`, `singleStateCommitPerBlock`, `bite2`, and `contractCreationReadOnly` in the `envs` section of `static_params.yaml` for various environments. These patches are set to either `0` (disabled) or specific future timestamps, depending on the environment. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR83-R86) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR190-R193) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR297-R300) [[4]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR406-R409)

**Container version update:**
- Updated the `schain` container version from `4.1.0-develop.86-bite` to `5.1.0-develop.36-bite` in `containers.json` to pull the latest development build.

**Consensus parameter adjustment:**
- Changed the `externalGasDifficulty` parameter from `0x01` to `0x00` in `schain_base_config.json`, which may affect block production or gas calculations.