### PR TITLE
Update to BITE2 versions

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "schain": {
     "name": "skalenetwork/schain",
-    "version": "4.1.0-develop.86-bite",
+    "version": "5.1.0-develop.37-bite",
     "custom_args": {
       "ulimits_list": [
         {

--- a/schain_precompiled_contracts.json
+++ b/schain_precompiled_contracts.json
@@ -228,5 +228,35 @@
       },
       "startingBlock": "0x0"
     }
+  },
+  "0x000000000000000000000000000000000000001B": {
+    "precompiled": {
+      "name": "submitCTX",
+      "linear": {
+        "base": 15,
+        "word": 0
+      },
+      "startingBlock": "0x0"
+    }
+  },
+  "0x000000000000000000000000000000000000001C": {
+    "precompiled": {
+      "name": "encryptECIES",
+      "linear": {
+        "base": 15,
+        "word": 0
+      },
+      "startingBlock": "0x0"
+    }
+  },
+  "0x000000000000000000000000000000000000001D": {
+    "precompiled": {
+      "name": "encryptTE",
+      "linear": {
+        "base": 15,
+        "word": 0
+      },
+      "startingBlock": "0x0"
+    }
   }
 }

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -80,6 +80,10 @@ envs:
       externalGasPatchTimestamp: 1728817200
       invalidTransactionFormatPatchTimestamp: 1746442800
       clearPartialReceiptsPatchTimestamp: 1746615600
+      currentBlockRandomPatchTimestamp: 1775729001
+      singleStateCommitPerBlockPatchTimestamp: 1775729001
+      bite2PatchTimestamp: 1775729001
+      contractCreationReadOnlyPatchTimestamp: 1775729001
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -102,6 +106,8 @@ envs:
         dynamicPricingMinPrice: 47619047620
         dynamicPricingMaxPrice: 1000000000000000000
         dynamicPricingStartPrice: 47619047620
+      admin:
+        automatic_repair: false
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -186,6 +192,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
+      currentBlockRandomPatchTimestamp: 1775158001
+      singleStateCommitPerBlockPatchTimestamp: 1775158001
+      bite2PatchTimestamp: 1775158001
+      contractCreationReadOnlyPatchTimestamp: 1775158001
       snapshotIntervalSec: 86400
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -208,6 +218,8 @@ envs:
         dynamicPricingMinPrice: 47619047620
         dynamicPricingMaxPrice: 1000000000000000000
         dynamicPricingStartPrice: 47619047620
+      admin:
+        automatic_repair: false
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -292,6 +304,10 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 0
       clearPartialReceiptsPatchTimestamp: 0
+      currentBlockRandomPatchTimestamp: 1775136600
+      singleStateCommitPerBlockPatchTimestamp: 1775136600
+      bite2PatchTimestamp: 1775136600
+      contractCreationReadOnlyPatchTimestamp: 1775136600
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
@@ -400,6 +416,10 @@ envs:
       externalGasPatchTimestamp: 1727353446
       invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
+      currentBlockRandomPatchTimestamp: 1775136600
+      singleStateCommitPerBlockPatchTimestamp: 1775136600
+      bite2PatchTimestamp: 1775136600
+      contractCreationReadOnlyPatchTimestamp: 1775136600
       snapshotIntervalSec: 3600
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000


### PR DESCRIPTION
This pull request introduces several important updates to the configuration and precompiled contract setup for the chain. The main changes include upgrading the `schain` container version, adding new precompiled contracts, and updating environment parameters to support new protocol features and administrative controls.

**Container and Precompiled Contract Updates:**

* Upgraded the `schain` container version from `4.1.0-develop.86-bite` to `5.1.0-develop.37-bite` in `containers.json`, ensuring the latest features and fixes are included.
* Added three new precompiled contracts (`submitCTX`, `encryptECIES`, and `encryptTE`) to `schain_precompiled_contracts.json`, each with their own address and gas cost parameters.

**Environment Parameter Enhancements:**

* Introduced new patch timestamps for features such as `currentBlockRandom`, `singleStateCommitPerBlock`, `bite2`, and `contractCreationReadOnly` across all environments in `static_params.yaml`, enabling these protocol upgrades at specified times. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR83-R86) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR195-R198) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR307-R310) [[4]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR419-R422)
* Added an `admin` section with `automatic_repair: false` to the configuration for improved administrative control in `static_params.yaml`. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR109-R110) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR221-R222)