### PR TITLE
Add contract creation read only patch timestamp

### DIFF
--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,7 +99,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562000
+      contractCreationReadOnlyPatchTimestamp: 1777028562
     ima:
       time_frame:
         before: 1800
@@ -205,7 +205,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562000
+      contractCreationReadOnlyPatchTimestamp: 1777028562
 
     ima:
       time_frame:
@@ -312,7 +312,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562000
+      contractCreationReadOnlyPatchTimestamp: 1777028562
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,7 +99,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1777028562000
     ima:
       time_frame:
         before: 1800
@@ -205,7 +205,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1777028562000
 
     ima:
       time_frame:
@@ -312,7 +312,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1777028562000
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,6 +99,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 0
     ima:
       time_frame:
         before: 1800
@@ -204,6 +205,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 0
 
     ima:
       time_frame:
@@ -310,6 +312,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 0
 
     ima:
       time_frame:
@@ -418,6 +421,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -295,24 +295,22 @@ envs:
       storageDestructionPatchTimestamp: 1699618500
       powCheckPatchTimestamp: 1699625700
       skipInvalidTransactionsPatchTimestamp: 1699632900
-      pushZeroPatchTimestamp: 1712142000
-      precompiledConfigPatchTimestamp: 1712314800
-      correctForkInPowPatchTimestamp: 1711969200
-      EIP1559TransactionsPatchTimestamp: 0
-      fastConsensusPatchTimestamp: 0
-      flexibleDeploymentPatchTimestamp: 0
-      verifyBlsSyncPatchTimestamp: 0
-      externalGasPatchTimestamp: 1727712000
-      invalidTransactionFormatPatchTimestamp: 0
-      clearPartialReceiptsPatchTimestamp: 0
-      snapshotIntervalSec: 3600
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 1777415467
-      currentBlockRandomPatchTimestamp: 1777415467
-      singleStateCommitPerBlockPatchTimestamp: 1777415467
-      contractCreationReadOnlyPatchTimestamp: 1777415467
+      pushZeroPatchTimestamp: 1708516800
+      precompiledConfigPatchTimestamp: 1708520400
+      correctForkInPowPatchTimestamp: 1708527600
+      EIP1559TransactionsPatchTimestamp: 1721304000
+      fastConsensusPatchTimestamp: 1721307600
+      flexibleDeploymentPatchTimestamp:
+        miniature-live-tabit: 1760357100
+        default: 0
+      verifyBlsSyncPatchTimestamp: 1721311200
+      externalGasPatchTimestamp: 1727370000
+      invalidTransactionFormatPatchTimestamp: 1760357100
+      clearPartialReceiptsPatchTimestamp: 1760364300
+      groupIndexInitPatchTimestamp: 1776781225
+      currentBlockRandomPatchTimestamp: 1776781225
+      singleStateCommitPerBlockPatchTimestamp: 1776781225
+      contractCreationReadOnlyPatchTimestamp: 1776781225
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -96,10 +96,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
     ima:
       time_frame:
         before: 1800
@@ -202,10 +202,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
 
     ima:
       time_frame:
@@ -309,10 +309,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
 
     ima:
       time_frame:
@@ -418,10 +418,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
 
     ima:
       time_frame:


### PR DESCRIPTION
This pull request adds a new configuration parameter, `contractCreationReadOnlyPatchTimestamp`, to multiple environment sections in the `static_params.yaml` file. The parameter is set to a specific timestamp value for most environments, and to `1` for one environment. This likely enables or schedules a read-only patch related to contract creation at the specified times.

Configuration updates:

* Added `contractCreationReadOnlyPatchTimestamp: 1777028562000` to several environment sections in `static_params.yaml` to control when the contract creation read-only patch takes effect. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR102) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR208) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aR315)
* Set `contractCreationReadOnlyPatchTimestamp: 1` for one specific environment in `static_params.yaml`, likely to enable the patch immediately or for testing purposes.