### PR TITLE
Update containers.json

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "5.0.0-beta.0",
+    "version": "5.0.0",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.2.0-beta.0
+    image: skalenetwork/transaction-manager:3.2.0
     network_mode: host
     tty: true
     volumes:
@@ -23,7 +23,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -46,7 +46,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     cap_add:
@@ -62,7 +62,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     command: "celery -A tools.notifications.tasks worker --loglevel=info"
@@ -86,7 +86,7 @@ services:
   bounty:
     <<: *sk_base
     container_name: sk_bounty
-    image: skalenetwork/bounty-agent:3.1.0-beta.0
+    image: skalenetwork/bounty-agent:3.1.0-stable.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}:/skale_vol
@@ -94,7 +94,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.2.0-beta.0
+    image: skalenetwork/watchdog:3.2.0-stable.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}/node_data/settings:/settings:ro


### PR DESCRIPTION
This pull request updates the `skaled` container version in the `containers.json` file from a beta release to the stable `5.0.0` version.

- Container version update:
  * Upgraded `skalenetwork/schain` from version `5.0.0-beta.0` to `5.0.0` in `containers.json`