### PR TITLE
Beta 5.0.0

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -1,7 +1,7 @@
 {
   "skaled": {
     "name": "skalenetwork/schain",
-    "version": "5.0.0-beta.0",
+    "version": "5.0.0",
     "custom_args": {
       "ulimits_list": [
         {

--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.2.0-beta.0
+    image: skalenetwork/transaction-manager:3.2.0
     network_mode: host
     tty: true
     volumes:
@@ -23,7 +23,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -47,7 +47,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     cap_add:
@@ -88,7 +88,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     cap_add:
@@ -120,7 +120,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-develop.1
+    image: skalenetwork/watchdog:3.2.0-stable.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.2.0-beta.0
+    image: skalenetwork/transaction-manager:3.2.0
     network_mode: host
     tty: true
     volumes:
@@ -23,7 +23,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -46,7 +46,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     cap_add:
@@ -62,7 +62,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     command: "celery -A tools.notifications.tasks worker --loglevel=info"
@@ -86,7 +86,7 @@ services:
   bounty:
     <<: *sk_base
     container_name: sk_bounty
-    image: skalenetwork/bounty-agent:3.1.0-beta.0
+    image: skalenetwork/bounty-agent:3.1.0-stable.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}:/skale_vol
@@ -94,7 +94,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.2.0-beta.0
+    image: skalenetwork/watchdog:3.2.0-stable.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}/node_data/settings:/settings:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
   bounty:
     <<: *sk_base
     container_name: sk_bounty
-    image: skalenetwork/bounty-agent:3.1.0-stable.0
+    image: skalenetwork/bounty-agent:3.1.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}:/skale_vol

--- a/schain_base_config.json
+++ b/schain_base_config.json
@@ -22,7 +22,8 @@
 		"blockReward": "0x4563918244F40000",
 		"externalGasDifficulty": "0x01",
 		"skaleDisableChainIdCheck": true,
-		"getResponseLogCountLimit": 10000
+		"getResponseLogCountLimit": 10000,
+		"getLogsBlocksLimit": 2000
 	},
 	"unddos": {
 		"origins": [

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,7 +99,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562000
+      contractCreationReadOnlyPatchTimestamp: 1777028562
     ima:
       time_frame:
         before: 1800
@@ -205,7 +205,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562000
+      contractCreationReadOnlyPatchTimestamp: 1777028562
 
     ima:
       time_frame:
@@ -312,7 +312,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562000
+      contractCreationReadOnlyPatchTimestamp: 1777028562
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,7 +99,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1777028562000
     ima:
       time_frame:
         before: 1800
@@ -205,7 +205,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1777028562000
 
     ima:
       time_frame:
@@ -312,7 +312,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1777028562000
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -99,6 +99,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 0
     ima:
       time_frame:
         before: 1800
@@ -204,6 +205,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 0
 
     ima:
       time_frame:
@@ -310,6 +312,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 0
 
     ima:
       time_frame:
@@ -418,6 +421,7 @@ envs:
       groupIndexInitPatchTimestamp: 0
       currentBlockRandomPatchTimestamp: 0
       singleStateCommitPerBlockPatchTimestamp: 0
+      contractCreationReadOnlyPatchTimestamp: 1
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -295,24 +295,22 @@ envs:
       storageDestructionPatchTimestamp: 1699618500
       powCheckPatchTimestamp: 1699625700
       skipInvalidTransactionsPatchTimestamp: 1699632900
-      pushZeroPatchTimestamp: 1712142000
-      precompiledConfigPatchTimestamp: 1712314800
-      correctForkInPowPatchTimestamp: 1711969200
-      EIP1559TransactionsPatchTimestamp: 0
-      fastConsensusPatchTimestamp: 0
-      flexibleDeploymentPatchTimestamp: 0
-      verifyBlsSyncPatchTimestamp: 0
-      externalGasPatchTimestamp: 1727712000
-      invalidTransactionFormatPatchTimestamp: 0
-      clearPartialReceiptsPatchTimestamp: 0
-      snapshotIntervalSec: 3600
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 1777415467
-      currentBlockRandomPatchTimestamp: 1777415467
-      singleStateCommitPerBlockPatchTimestamp: 1777415467
-      contractCreationReadOnlyPatchTimestamp: 1777415467
+      pushZeroPatchTimestamp: 1708516800
+      precompiledConfigPatchTimestamp: 1708520400
+      correctForkInPowPatchTimestamp: 1708527600
+      EIP1559TransactionsPatchTimestamp: 1721304000
+      fastConsensusPatchTimestamp: 1721307600
+      flexibleDeploymentPatchTimestamp:
+        miniature-live-tabit: 1760357100
+        default: 0
+      verifyBlsSyncPatchTimestamp: 1721311200
+      externalGasPatchTimestamp: 1727370000
+      invalidTransactionFormatPatchTimestamp: 1760357100
+      clearPartialReceiptsPatchTimestamp: 1760364300
+      groupIndexInitPatchTimestamp: 1776781225
+      currentBlockRandomPatchTimestamp: 1776781225
+      singleStateCommitPerBlockPatchTimestamp: 1776781225
+      contractCreationReadOnlyPatchTimestamp: 1776781225
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -92,14 +92,14 @@ envs:
       externalGasPatchTimestamp: 1728817200
       invalidTransactionFormatPatchTimestamp: 1746442800
       clearPartialReceiptsPatchTimestamp: 1746615600
-      snapshotIntervalSec: 86400
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
       groupIndexInitPatchTimestamp: 1777415467
       currentBlockRandomPatchTimestamp: 1777415467
       singleStateCommitPerBlockPatchTimestamp: 1777415467
       contractCreationReadOnlyPatchTimestamp: 1777415467
+      snapshotIntervalSec: 86400
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
     ima:
       time_frame:
         before: 1800
@@ -198,14 +198,14 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
-      snapshotIntervalSec: 86400
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
       groupIndexInitPatchTimestamp: 1777415467
       currentBlockRandomPatchTimestamp: 1777415467
       singleStateCommitPerBlockPatchTimestamp: 1777415467
       contractCreationReadOnlyPatchTimestamp: 1777415467
+      snapshotIntervalSec: 86400
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
 
     ima:
       time_frame:
@@ -311,6 +311,10 @@ envs:
       currentBlockRandomPatchTimestamp: 1776781225
       singleStateCommitPerBlockPatchTimestamp: 1776781225
       contractCreationReadOnlyPatchTimestamp: 1776781225
+      snapshotIntervalSec: 3600
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
 
     ima:
       time_frame:
@@ -412,14 +416,14 @@ envs:
       externalGasPatchTimestamp: 1727353446
       invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
-      snapshotIntervalSec: 3600
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
       groupIndexInitPatchTimestamp: 1777415467
       currentBlockRandomPatchTimestamp: 1777415467
       singleStateCommitPerBlockPatchTimestamp: 1777415467
       contractCreationReadOnlyPatchTimestamp: 1777415467
+      snapshotIntervalSec: 3600
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
 
     ima:
       time_frame:

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -46,7 +46,6 @@ envs:
       disk: 1900000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"
@@ -169,7 +168,6 @@ envs:
       disk: 200000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"
@@ -276,7 +274,6 @@ envs:
       disk: 200000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"
@@ -387,7 +384,6 @@ envs:
       disk: 80000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -96,10 +96,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
     ima:
       time_frame:
         before: 1800
@@ -202,10 +202,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
 
     ima:
       time_frame:
@@ -309,10 +309,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1777028562
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
 
     ima:
       time_frame:
@@ -418,10 +418,10 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      groupIndexInitPatchTimestamp: 0
-      currentBlockRandomPatchTimestamp: 0
-      singleStateCommitPerBlockPatchTimestamp: 0
-      contractCreationReadOnlyPatchTimestamp: 1
+      groupIndexInitPatchTimestamp: 1777415467
+      currentBlockRandomPatchTimestamp: 1777415467
+      singleStateCommitPerBlockPatchTimestamp: 1777415467
+      contractCreationReadOnlyPatchTimestamp: 1777415467
 
     ima:
       time_frame:


### PR DESCRIPTION
This pull request updates several container images to stable releases and introduces important changes to protocol patch activation timestamps in `static_params.yaml`. The main goal is to transition from beta to stable versions for key services and to update network upgrade timing parameters, including the addition of new patch timestamps.

Container image updates:

* Upgraded `skalenetwork/schain` from version `5.0.0-beta.0` to `5.0.0` in `containers.json`.
* Updated service images in `docker-compose.yml` to stable versions:
  - `transaction-manager` to `3.2.0`
  - `admin`, `api`, and `celery` to `3.3.0` [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L26-R26) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L49-R49) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L65-R65)
  - `bounty-agent` to `3.1.0-stable.0` and `watchdog` to `3.2.0-stable.0`

Protocol patch timestamp updates:

* Changed multiple patch activation timestamps in `static_params.yaml` from `0` (disabled) to specific future Unix timestamps, enabling these protocol upgrades. This includes `groupIndexInitPatchTimestamp`, `currentBlockRandomPatchTimestamp`, `singleStateCommitPerBlockPatchTimestamp`, and adds `contractCreationReadOnlyPatchTimestamp`. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL99-R102) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL204-R208) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL418-R422)
* Updated and added several other protocol patch timestamps in the `mainnet` section, including `pushZeroPatchTimestamp`, `precompiledConfigPatchTimestamp`, `correctForkInPowPatchTimestamp`, `EIP1559TransactionsPatchTimestamp`, `fastConsensusPatchTimestamp`, `flexibleDeploymentPatchTimestamp`, `verifyBlsSyncPatchTimestamp`, `externalGasPatchTimestamp`, `invalidTransactionFormatPatchTimestamp`, and `clearPartialReceiptsPatchTimestamp`, with new values and per-network overrides where needed.