### PR TITLE
Update qanet config

### DIFF
--- a/schain_base_config.json
+++ b/schain_base_config.json
@@ -22,7 +22,8 @@
 		"blockReward": "0x4563918244F40000",
 		"externalGasDifficulty": "0x01",
 		"skaleDisableChainIdCheck": true,
-		"getResponseLogCountLimit": 10000
+		"getResponseLogCountLimit": 10000,
+		"getLogsBlocksLimit": 2000
 	},
 	"unddos": {
 		"origins": [

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -92,14 +92,14 @@ envs:
       externalGasPatchTimestamp: 1728817200
       invalidTransactionFormatPatchTimestamp: 1746442800
       clearPartialReceiptsPatchTimestamp: 1746615600
-      snapshotIntervalSec: 86400
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
       groupIndexInitPatchTimestamp: 1777415467
       currentBlockRandomPatchTimestamp: 1777415467
       singleStateCommitPerBlockPatchTimestamp: 1777415467
       contractCreationReadOnlyPatchTimestamp: 1777415467
+      snapshotIntervalSec: 86400
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
     ima:
       time_frame:
         before: 1800
@@ -198,14 +198,14 @@ envs:
       externalGasPatchTimestamp: 1727712000
       invalidTransactionFormatPatchTimestamp: 1745319600
       clearPartialReceiptsPatchTimestamp: 1745323200
-      snapshotIntervalSec: 86400
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
       groupIndexInitPatchTimestamp: 1777415467
       currentBlockRandomPatchTimestamp: 1777415467
       singleStateCommitPerBlockPatchTimestamp: 1777415467
       contractCreationReadOnlyPatchTimestamp: 1777415467
+      snapshotIntervalSec: 86400
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
 
     ima:
       time_frame:
@@ -311,6 +311,10 @@ envs:
       currentBlockRandomPatchTimestamp: 1776781225
       singleStateCommitPerBlockPatchTimestamp: 1776781225
       contractCreationReadOnlyPatchTimestamp: 1776781225
+      snapshotIntervalSec: 3600
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
 
     ima:
       time_frame:
@@ -412,14 +416,14 @@ envs:
       externalGasPatchTimestamp: 1727353446
       invalidTransactionFormatPatchTimestamp: 1741956440
       clearPartialReceiptsPatchTimestamp: 1742042840
-      snapshotIntervalSec: 3600
-      emptyBlockIntervalMs: 10000
-      snapshotDownloadTimeout: 18000
-      snapshotDownloadInactiveTimeout: 120
       groupIndexInitPatchTimestamp: 1777415467
       currentBlockRandomPatchTimestamp: 1777415467
       singleStateCommitPerBlockPatchTimestamp: 1777415467
       contractCreationReadOnlyPatchTimestamp: 1777415467
+      snapshotIntervalSec: 3600
+      emptyBlockIntervalMs: 10000
+      snapshotDownloadTimeout: 18000
+      snapshotDownloadInactiveTimeout: 120
 
     ima:
       time_frame:


### PR DESCRIPTION
This pull request updates configuration files to add a new logs block limit parameter and to adjust how certain snapshot and block interval settings are defined for different environments. The main changes are the addition of a new logs limit in `schain_base_config.json` and the reordering or addition of snapshot-related parameters in several environment definitions in `static_params.yaml`.

**Configuration parameter updates:**

* Added the `getLogsBlocksLimit` parameter (set to 2000) to the `schain_base_config.json` file to limit the number of blocks processed when fetching logs.

**Environment settings adjustments in `static_params.yaml`:**

* Reordered or restored the snapshot and block interval parameters (`snapshotIntervalSec`, `emptyBlockIntervalMs`, `snapshotDownloadTimeout`, `snapshotDownloadInactiveTimeout`) in multiple environment sections to ensure they are consistently defined. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL95-R102) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL201-R208) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL415-R426)
* Added snapshot and block interval parameters for an environment that previously did not have them, setting `snapshotIntervalSec` to 3600 and other values as appropriate.