### PR TITLE
Remove iptables persistent

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.2.0-beta.0
+    image: skalenetwork/transaction-manager:3.2.0
     network_mode: host
     tty: true
     volumes:
@@ -23,7 +23,7 @@ services:
   boot-admin:
     <<: *sk_base
     container_name: sk_boot_admin
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -47,7 +47,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -71,7 +71,7 @@ services:
   boot-api:
     <<: *sk_base
     container_name: sk_boot_api
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     cap_add:
@@ -88,7 +88,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0-beta.2
+    image: skalenetwork/admin:3.3.0
     network_mode: host
     tty: true
     cap_add:
@@ -120,7 +120,7 @@ services:
   watchdog:
     <<: *sk_base
     container_name: sk_watchdog
-    image: skalenetwork/watchdog:3.1.0-develop.1
+    image: skalenetwork/watchdog:3.2.0-stable.0
     network_mode: host
     environment:
       ALLOWED_TS_DIFF: 300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
   bounty:
     <<: *sk_base
     container_name: sk_bounty
-    image: skalenetwork/bounty-agent:3.1.0-stable.0
+    image: skalenetwork/bounty-agent:3.1.0
     network_mode: host
     volumes:
       - ${SKALE_DIR}:/skale_vol

--- a/static_params.yaml
+++ b/static_params.yaml
@@ -46,7 +46,6 @@ envs:
       disk: 1900000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"
@@ -169,7 +168,6 @@ envs:
       disk: 200000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"
@@ -276,7 +274,6 @@ envs:
       disk: 200000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"
@@ -387,7 +384,6 @@ envs:
       disk: 80000000000
 
     package:
-      iptables-persistent: 1.0.4
       lvm2: 2.02.0
       btrfs-progs: 4.15.1
       lsof: "4.89"


### PR DESCRIPTION
This pull request updates several service images in the `docker-compose-fair.yml` and `docker-compose.yml` files to use newer stable versions, and removes the `iptables-persistent` package from all environments in `static_params.yaml`. These changes help ensure the deployment uses up-to-date, stable images and streamlines the package requirements.

**Docker image updates:**

* Updated `transaction-manager` to use `skalenetwork/transaction-manager:3.2.0` instead of the beta version in `docker-compose-fair.yml`.
* Updated `boot-admin`, `admin`, `boot-api`, and `api` services to use `skalenetwork/admin:3.3.0` instead of the beta version in `docker-compose-fair.yml`. [[1]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L26-R26) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L50-R50) [[3]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L74-R74) [[4]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L91-R91)
* Updated `watchdog` to use `skalenetwork/watchdog:3.2.0-stable.0` in `docker-compose-fair.yml`.
* Updated `bounty` to use `skalenetwork/bounty-agent:3.1.0` in `docker-compose.yml`.

**Package cleanup:**

* Removed the `iptables-persistent` package from all environment configurations in `static_params.yaml`. [[1]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL49) [[2]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL172) [[3]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL279) [[4]](diffhunk://#diff-82eb58143b43974944d4f50a74eee89a080c138a517f291b2f50a7e2f684f14aL390)