### PR TITLE
Beta to stable

### DIFF
--- a/docker-compose-fair.yml
+++ b/docker-compose-fair.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.2.0
+    image: skalenetwork/transaction-manager:3.2.1
     network_mode: host
     tty: true
     volumes:
@@ -38,7 +38,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: ["CMD", "python3", "healthchecks/admin.py"]
+      test: [ "CMD", "python3", "healthchecks/admin.py" ]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -62,7 +62,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: ["CMD", "python3", "healthchecks/admin.py"]
+      test: [ "CMD", "python3", "healthchecks/admin.py" ]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -172,7 +172,8 @@ services:
       - "--path.procfs=/host/proc"
       - "--path.rootfs=/rootfs"
       - "--path.sysfs=/host/sys"
-      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/li\
+        b/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   transaction-manager:
     <<: *sk_base
     container_name: sk_tm
-    image: skalenetwork/transaction-manager:3.2.0
+    image: skalenetwork/transaction-manager:3.2.1
     network_mode: host
     tty: true
     volumes:
@@ -37,7 +37,7 @@ services:
       - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
-      test: ["CMD", "python3", "healthchecks/admin.py"]
+      test: [ "CMD", "python3", "healthchecks/admin.py" ]
       interval: 1m
       timeout: 10s
       retries: 2
@@ -149,7 +149,8 @@ services:
       - "--path.procfs=/host/proc"
       - "--path.rootfs=/rootfs"
       - "--path.sysfs=/host/sys"
-      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
+      - "--collector.filesystem.mount-points-exclude=^/(mnt|dev|proc|sys|var/li\
+        b/docker/.+|var/lib/kubelet/.+)($$|/)"
     network_mode: host
 
   filebeat:


### PR DESCRIPTION
This pull request updates the `transaction-manager` service image version and improves the formatting of a long command-line argument for the `node-exporter` service in both `docker-compose.yml` and `docker-compose-fair.yml`. These changes help ensure consistency across environments and improve readability.

Service updates:

* Bumped the `transaction-manager` image version from `3.2.0` to `3.2.1` in both `docker-compose.yml` and `docker-compose-fair.yml` to use the latest release. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-R16) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L16-R16)

Configuration improvements:

* Reformatted the `--collector.filesystem.mount-points-exclude` argument for the `node-exporter` service in both compose files to split the long string across two lines, improving readability without changing functionality. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L152-R153) [[2]](diffhunk://#diff-6a4caab5b11139c371f21ca431b70b9915d64507c8f0bfb95fbdd5af26222fe1L175-R176)