### PR TITLE
Update admin to 3.3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   admin:
     <<: *sk_base
     container_name: sk_admin
-    image: skalenetwork/admin:3.3.0
+    image: skalenetwork/admin:3.3.1
     cpu_shares: 192
     network_mode: host
     tty: true
@@ -46,7 +46,7 @@ services:
   api:
     <<: *sk_base
     container_name: sk_api
-    image: skalenetwork/admin:3.3.0
+    image: skalenetwork/admin:3.3.1
     network_mode: host
     tty: true
     cap_add:
@@ -62,7 +62,7 @@ services:
   celery:
     <<: *sk_base
     container_name: celery
-    image: skalenetwork/admin:3.3.0
+    image: skalenetwork/admin:3.3.1
     network_mode: host
     tty: true
     command: "celery -A tools.notifications.tasks worker --loglevel=info"


### PR DESCRIPTION
This pull request updates the Docker images used for the `admin`, `api`, and `celery` services in the `docker-compose.yml` file to use version `3.3.1` of the `skalenetwork/admin` image instead of `3.3.0`. This ensures all services are running the latest version of the application.

**Docker image version updates:**

* Updated the `admin` service to use the `skalenetwork/admin:3.3.1` image.
* Updated the `api` service to use the `skalenetwork/admin:3.3.1` image.
* Updated the `celery` service to use the `skalenetwork/admin:3.3.1` image.